### PR TITLE
Add PostgresqlTypes.Geometry for the PostGIS geometry type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This package provides support for nearly all PostgreSQL data types, including:
 - **Date/time types**: Date, Time, Timestamp, Timestamptz, Timetz, Interval
 - **Network address types**: Inet, Cidr, Macaddr, Macaddr8
 - **Geometric types**: Point, Line, Lseg, Box, Path, Polygon, Circle
+- **PostGIS extension type**: Geometry (EWKB / hex EWKB; OID resolved dynamically by name at query time)
 - **Bit string types**: Bit, Varbit
 - **UUID type**: Uuid
 - **JSON types**: Json, Jsonb

--- a/postgresql-types.cabal
+++ b/postgresql-types.cabal
@@ -222,6 +222,7 @@ test-suite unit-tests
     PostgresqlTypes.DateSpec
     PostgresqlTypes.Float4Spec
     PostgresqlTypes.Float8Spec
+    PostgresqlTypes.GeometrySpec
     PostgresqlTypes.HstoreSpec
     PostgresqlTypes.InetSpec
     PostgresqlTypes.Int2Spec

--- a/postgresql-types.cabal
+++ b/postgresql-types.cabal
@@ -265,6 +265,7 @@ test-suite unit-tests
     base >=4.11 && <5,
     bytestring >=0.10 && <0.13,
     containers >=0.6 && <0.9,
+    hashable >=1.3 && <2,
     hspec >=2.11 && <3,
     postgresql-types,
     postgresql-types-algebra ^>=0.1,

--- a/postgresql-types.cabal
+++ b/postgresql-types.cabal
@@ -114,6 +114,7 @@ library
     PostgresqlTypes.Date
     PostgresqlTypes.Float4
     PostgresqlTypes.Float8
+    PostgresqlTypes.Geometry
     PostgresqlTypes.Hstore
     PostgresqlTypes.Inet
     PostgresqlTypes.Int2

--- a/src/integration-tests/Main.hs
+++ b/src/integration-tests/Main.hs
@@ -1,5 +1,10 @@
 module Main (main) where
 
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as BS8
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text.Encoding
+import Data.Word (Word16)
 import qualified Database.PostgreSQL.LibPQ as Pq
 import IntegrationTests.Scopes
 import IntegrationTests.Scripts
@@ -80,12 +85,13 @@ main =
           withType @(PostgresqlTypes.Varchar 255) [mappingSpec]
 
       -- PostGIS is an extension type; the @geometry@ OID is assigned by
-      -- @CREATE EXTENSION postgis@, so we run the integration tests against
-      -- the postgis/postgis image and enable the extension before distributing
-      -- connections from the pool.
+      -- @CREATE EXTENSION postgis@. We enable the extension once at the
+      -- container level (via a short-lived throwaway connection) so every
+      -- subsequent connection the pool hands out already sees the registered
+      -- @geometry@ type.
       withContainer "postgis/postgis:17-3.5" do
-        withConnection Nothing do
-          beforeAllWith enablePostgisExtension do
+        beforeAllWith enablePostgisExtension do
+          withConnection Nothing do
             withType @PostgresqlTypes.Geometry [mappingSpec]
 
       withContainer "postgres:14" do
@@ -198,22 +204,44 @@ main =
           withType @(PostgresqlTypes.Varchar 0) [mappingSpec]
           withType @(PostgresqlTypes.Varchar 255) [mappingSpec]
 
--- | Runs @CREATE EXTENSION IF NOT EXISTS postgis@ on the first pooled
--- connection handed to us; all subsequent connections see the registered
--- @geometry@ type because the extension is persisted in the database, not
--- per-connection state.
-enablePostgisExtension :: Pq.Connection -> IO Pq.Connection
-enablePostgisExtension connection = do
-  result <- Pq.exec connection "CREATE EXTENSION IF NOT EXISTS postgis;"
+-- | Opens a one-shot @libpq@ connection to the container, runs
+-- @CREATE EXTENSION IF NOT EXISTS postgis@, and closes it again — so the
+-- subsequent pool the tests draw from starts on a database where the
+-- @geometry@ type is already registered. Runs at the container scope
+-- (@(Text, Word16)@), not at the per-test connection scope, to avoid
+-- capturing and reusing a pooled connection under concurrent tests.
+enablePostgisExtension :: (Text, Word16) -> IO (Text, Word16)
+enablePostgisExtension (host, port) = do
+  let connectionString =
+        ByteString.intercalate
+          " "
+          [ "host=" <> Text.Encoding.encodeUtf8 host,
+            "port=" <> BS8.pack (show port),
+            "user=postgres",
+            "password=postgres",
+            "dbname=postgres"
+          ]
+  connection <- Pq.connectdb connectionString
+  status <- Pq.status connection
+  case status of
+    Pq.ConnectionOk -> pure ()
+    _ -> do
+      message <- Pq.errorMessage connection
+      Pq.finish connection
+      fail ("enablePostgisExtension: connection failed: " <> show message)
+  result <- Pq.exec connection "CREATE EXTENSION IF NOT EXISTS postgis"
   case result of
     Nothing -> do
       message <- Pq.errorMessage connection
+      Pq.finish connection
       fail ("CREATE EXTENSION postgis failed: " <> show message)
     Just r -> do
-      status <- Pq.resultStatus r
-      case status of
+      resultStatus <- Pq.resultStatus r
+      case resultStatus of
         Pq.CommandOk -> pure ()
         _ -> do
           message <- Pq.resultErrorMessage r
-          fail ("CREATE EXTENSION postgis unexpected status " <> show status <> ": " <> show message)
-  pure connection
+          Pq.finish connection
+          fail ("CREATE EXTENSION postgis unexpected status " <> show resultStatus <> ": " <> show message)
+  Pq.finish connection
+  pure (host, port)

--- a/src/integration-tests/Main.hs
+++ b/src/integration-tests/Main.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import qualified Database.PostgreSQL.LibPQ as Pq
 import IntegrationTests.Scopes
 import IntegrationTests.Scripts
 import qualified PostgresqlTypes as PostgresqlTypes
@@ -77,6 +78,15 @@ main =
           withType @(PostgresqlTypes.Varbit 128) [mappingSpec]
           withType @(PostgresqlTypes.Varchar 0) [mappingSpec]
           withType @(PostgresqlTypes.Varchar 255) [mappingSpec]
+
+      -- PostGIS is an extension type; the @geometry@ OID is assigned by
+      -- @CREATE EXTENSION postgis@, so we run the integration tests against
+      -- the postgis/postgis image and enable the extension before distributing
+      -- connections from the pool.
+      withContainer "postgis/postgis:17-3.5" do
+        withConnection Nothing do
+          beforeAllWith enablePostgisExtension do
+            withType @PostgresqlTypes.Geometry [mappingSpec]
 
       withContainer "postgres:14" do
         withConnection (Just 3) do
@@ -187,3 +197,23 @@ main =
           withType @(PostgresqlTypes.Varbit 128) [mappingSpec]
           withType @(PostgresqlTypes.Varchar 0) [mappingSpec]
           withType @(PostgresqlTypes.Varchar 255) [mappingSpec]
+
+-- | Runs @CREATE EXTENSION IF NOT EXISTS postgis@ on the first pooled
+-- connection handed to us; all subsequent connections see the registered
+-- @geometry@ type because the extension is persisted in the database, not
+-- per-connection state.
+enablePostgisExtension :: Pq.Connection -> IO Pq.Connection
+enablePostgisExtension connection = do
+  result <- Pq.exec connection "CREATE EXTENSION IF NOT EXISTS postgis;"
+  case result of
+    Nothing -> do
+      message <- Pq.errorMessage connection
+      fail ("CREATE EXTENSION postgis failed: " <> show message)
+    Just r -> do
+      status <- Pq.resultStatus r
+      case status of
+        Pq.CommandOk -> pure ()
+        _ -> do
+          message <- Pq.resultErrorMessage r
+          fail ("CREATE EXTENSION postgis unexpected status " <> show status <> ": " <> show message)
+  pure connection

--- a/src/integration-tests/Main.hs
+++ b/src/integration-tests/Main.hs
@@ -88,11 +88,15 @@ main =
       -- @CREATE EXTENSION postgis@. We enable the extension once at the
       -- container level (via a short-lived throwaway connection) so every
       -- subsequent connection the pool hands out already sees the registered
-      -- @geometry@ type.
+      -- @geometry@ type. The pool is deliberately smaller than the default
+      -- 'withConnection' size (10 vs 100): it only serves this single type,
+      -- and a smaller pool keeps the number of concurrent TCP sockets
+      -- inside the GitHub-runner limit alongside the other 3 containers.
       withContainer "postgis/postgis:17-3.5" do
         beforeAllWith enablePostgisExtension do
-          withConnection Nothing do
-            withType @PostgresqlTypes.Geometry [mappingSpec]
+          withConnectionPool 10 Nothing $
+            withTQueueElement pure do
+              withType @PostgresqlTypes.Geometry [mappingSpec]
 
       withContainer "postgres:14" do
         withConnection (Just 3) do

--- a/src/integration-tests/Main.hs
+++ b/src/integration-tests/Main.hs
@@ -1,11 +1,5 @@
 module Main (main) where
 
-import qualified Data.ByteString as ByteString
-import qualified Data.ByteString.Char8 as BS8
-import Data.Text (Text)
-import qualified Data.Text.Encoding as Text.Encoding
-import Data.Word (Word16)
-import qualified Database.PostgreSQL.LibPQ as Pq
 import IntegrationTests.Scopes
 import IntegrationTests.Scripts
 import qualified PostgresqlTypes as PostgresqlTypes
@@ -84,19 +78,19 @@ main =
           withType @(PostgresqlTypes.Varchar 0) [mappingSpec]
           withType @(PostgresqlTypes.Varchar 255) [mappingSpec]
 
-      -- PostGIS is an extension type; the @geometry@ OID is assigned by
-      -- @CREATE EXTENSION postgis@. We enable the extension once at the
-      -- container level (via a short-lived throwaway connection) so every
-      -- subsequent connection the pool hands out already sees the registered
-      -- @geometry@ type. The pool is deliberately smaller than the default
-      -- 'withConnection' size (10 vs 100): it only serves this single type,
-      -- and a smaller pool keeps the number of concurrent TCP sockets
-      -- inside the GitHub-runner limit alongside the other 3 containers.
+      -- The 'postgis/postgis' image is @postgres@ plus a pre-installed
+      -- PostGIS build; its initdb already runs @CREATE EXTENSION postgis@
+      -- inside the default database, so any connection the pool hands out
+      -- sees the registered @geometry@ type immediately.
+      --
+      -- The pool is deliberately smaller than the default 'withConnection'
+      -- size (10 vs 100): this container only serves a single type, and a
+      -- smaller pool keeps the concurrent-TCP-socket count inside the
+      -- GitHub-runner comfort zone alongside the other 3 containers.
       withContainer "postgis/postgis:17-3.5" do
-        beforeAllWith enablePostgisExtension do
-          withConnectionPool 10 Nothing $
-            withTQueueElement pure do
-              withType @PostgresqlTypes.Geometry [mappingSpec]
+        withConnectionPool 10 Nothing $
+          withTQueueElement pure do
+            withType @PostgresqlTypes.Geometry [mappingSpec]
 
       withContainer "postgres:14" do
         withConnection (Just 3) do
@@ -207,45 +201,3 @@ main =
           withType @(PostgresqlTypes.Varbit 128) [mappingSpec]
           withType @(PostgresqlTypes.Varchar 0) [mappingSpec]
           withType @(PostgresqlTypes.Varchar 255) [mappingSpec]
-
--- | Opens a one-shot @libpq@ connection to the container, runs
--- @CREATE EXTENSION IF NOT EXISTS postgis@, and closes it again — so the
--- subsequent pool the tests draw from starts on a database where the
--- @geometry@ type is already registered. Runs at the container scope
--- (@(Text, Word16)@), not at the per-test connection scope, to avoid
--- capturing and reusing a pooled connection under concurrent tests.
-enablePostgisExtension :: (Text, Word16) -> IO (Text, Word16)
-enablePostgisExtension (host, port) = do
-  let connectionString =
-        ByteString.intercalate
-          " "
-          [ "host=" <> Text.Encoding.encodeUtf8 host,
-            "port=" <> BS8.pack (show port),
-            "user=postgres",
-            "password=postgres",
-            "dbname=postgres"
-          ]
-  connection <- Pq.connectdb connectionString
-  status <- Pq.status connection
-  case status of
-    Pq.ConnectionOk -> pure ()
-    _ -> do
-      message <- Pq.errorMessage connection
-      Pq.finish connection
-      fail ("enablePostgisExtension: connection failed: " <> show message)
-  result <- Pq.exec connection "CREATE EXTENSION IF NOT EXISTS postgis"
-  case result of
-    Nothing -> do
-      message <- Pq.errorMessage connection
-      Pq.finish connection
-      fail ("CREATE EXTENSION postgis failed: " <> show message)
-    Just r -> do
-      resultStatus <- Pq.resultStatus r
-      case resultStatus of
-        Pq.CommandOk -> pure ()
-        _ -> do
-          message <- Pq.resultErrorMessage r
-          Pq.finish connection
-          fail ("CREATE EXTENSION postgis unexpected status " <> show resultStatus <> ": " <> show message)
-  Pq.finish connection
-  pure (host, port)

--- a/src/library/PostgresqlTypes.hs
+++ b/src/library/PostgresqlTypes.hs
@@ -47,6 +47,9 @@ module PostgresqlTypes
     Polygon,
     Circle,
 
+    -- * PostGIS Extension Types
+    Geometry,
+
     -- * Bit String Types
     Bit,
     Varbit,
@@ -82,6 +85,7 @@ import PostgresqlTypes.Citext
 import PostgresqlTypes.Date
 import PostgresqlTypes.Float4
 import PostgresqlTypes.Float8
+import PostgresqlTypes.Geometry
 import PostgresqlTypes.Hstore
 import PostgresqlTypes.Inet
 import PostgresqlTypes.Int2

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -167,12 +167,16 @@ instance Hashable Geometry where
 
 instance Arbitrary Geometry where
   arbitrary = do
-    srid <- oneof [pure Nothing, Just <$> arbitrary]
+    -- PostGIS treats @SRID = 0@ as "no SRID" and drops the SRID flag on
+    -- output, so @SRID 0@ doesn't round-trip exactly. Stick to the
+    -- positive half of 'Int32' — which is where real EPSG / spatial_ref_sys
+    -- codes live — so wire-format round-trip is an equality.
+    srid <- oneof [pure Nothing, Just <$> choose (1, maxBound)]
     dim <- elements [XY, XYZ, XYM, XYZM]
     shape <- sized (shapeGen dim)
     pure (Geometry srid shape)
   shrink (Geometry srid shape) =
-    [Geometry srid' shape | srid' <- shrink srid]
+    [Geometry srid' shape | srid' <- shrink srid, maybe True (> 0) srid']
 
 -- * Dimension handling
 

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -7,10 +7,6 @@ module PostgresqlTypes.Geometry
     -- * Smart constructors
     fromShape,
     fromShapeWithSrid,
-
-    -- * Accessors
-    geometrySrid,
-    geometryShape,
   )
 where
 
@@ -45,15 +41,15 @@ import qualified TextBuilder
 -- @CREATE EXTENSION postgis@ time and receives a different OID in each
 -- database. 'baseOid' and 'arrayOid' are therefore 'Nothing', and drivers
 -- resolve the OID by 'typeName' at query time.
-data Geometry
-  = -- | __Prefer 'fromShape' / 'fromShapeWithSrid'__: the constructor does
-    --   not enforce dimension consistency across nested shapes.
-    Geometry
-      -- | Spatial reference ID. Sub-geometries inside a 'GeometryCollection'
-      --   inherit this from the outer value; EWKB only stores SRID on the
-      --   top-level geometry.
-      !(Maybe Int32)
-      !Shape
+-- | __Prefer 'fromShape' / 'fromShapeWithSrid'__: the raw constructor does
+-- not enforce dimension consistency across nested shapes.
+data Geometry = Geometry
+  { -- | Spatial reference ID. Sub-geometries inside a 'GeometryCollection'
+    --   inherit this from the outer value; EWKB only stores SRID on the
+    --   top-level geometry.
+    geometrySrid :: !(Maybe Int32),
+    geometryShape :: !Shape
+  }
   deriving stock (Eq, Ord)
   deriving (Show, Read, IsString) via (ViaIsScalar Geometry)
 
@@ -101,15 +97,7 @@ fromShape = fromShapeWithSrid Nothing
 fromShapeWithSrid :: Maybe Int32 -> Shape -> Either Text Geometry
 fromShapeWithSrid srid shape = do
   void (shapeDim shape)
-  pure (Geometry srid shape)
-
--- | Top-level SRID, if any.
-geometrySrid :: Geometry -> Maybe Int32
-geometrySrid (Geometry s _) = s
-
--- | Top-level shape.
-geometryShape :: Geometry -> Shape
-geometryShape (Geometry _ s) = s
+  pure (Geometry {geometrySrid = srid, geometryShape = shape})
 
 -- * IsScalar instance
 

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -140,6 +140,9 @@ instance IsScalar Geometry where
     case parseHexBytes hexText of
       Left err -> fail ("geometry: " <> err)
       Right bytes -> case PtrPeeker.runVariableOnByteString binaryDecoder bytes of
+        -- 'runVariableOnByteString' reports the leftover as an 'Int' byte
+        -- count, not the bytes themselves, so it is safe to include
+        -- verbatim in the error message.
         Left leftover -> fail ("geometry: binary decoder left " <> show leftover <> " unconsumed bytes")
         Right (Left err) -> fail ("geometry: " <> show err)
         Right (Right value) -> pure value
@@ -167,11 +170,18 @@ instance IsScalar Geometry where
 -- * Arbitrary / Hashable
 
 instance Hashable Geometry where
-  -- Hash via the canonical EWKB bytes so two equal 'Geometry' values always
-  -- hash the same, independent of any structural irrelevance. The
-  -- binaryEncoder is bit-stable.
-  hashWithSalt salt geom =
-    salt `hashWithSalt` Write.toByteString (binaryEncoder geom)
+  -- Hash via the canonical EWKB bytes for well-formed geometries so two
+  -- equal 'Geometry' values always hash the same, independent of any
+  -- structural irrelevance. For malformed values that can be constructed via
+  -- the exported raw constructor (e.g. shape trees with mixed coordinate
+  -- dimensionalities), avoid routing through 'binaryEncoder', which would
+  -- otherwise call 'error' and make hashing partial.
+  hashWithSalt salt geom@(Geometry srid shape) =
+    case shapeDim shape of
+      Right _ ->
+        salt `hashWithSalt` Write.toByteString (binaryEncoder geom)
+      Left dimErr ->
+        salt `hashWithSalt` srid `hashWithSalt` dimErr
 
 instance Arbitrary Geometry where
   arbitrary = do
@@ -396,9 +406,12 @@ decodeShape le dim typeCode
         np <- readWord32 le
         replicateM (fromIntegral np) (readCoord le dim)
       pure (Right (Polygon rings))
-  | typeCode == typeCodeMultiPoint = decodeMulti le (\case Point c -> Just c; _ -> Nothing) MultiPoint
-  | typeCode == typeCodeMultiLineString = decodeMulti le (\case LineString cs -> Just cs; _ -> Nothing) MultiLineString
-  | typeCode == typeCodeMultiPolygon = decodeMulti le (\case Polygon rings -> Just rings; _ -> Nothing) MultiPolygon
+  | typeCode == typeCodeMultiPoint =
+      decodeMulti le "MultiPoint" "Point" (\case Point c -> Just c; _ -> Nothing) MultiPoint
+  | typeCode == typeCodeMultiLineString =
+      decodeMulti le "MultiLineString" "LineString" (\case LineString cs -> Just cs; _ -> Nothing) MultiLineString
+  | typeCode == typeCodeMultiPolygon =
+      decodeMulti le "MultiPolygon" "Polygon" (\case Polygon rings -> Just rings; _ -> Nothing) MultiPolygon
   | typeCode == typeCodeGeometryCollection = do
       n <- readWord32 le
       subs <- replicateM (fromIntegral n) (readGeometry False)
@@ -409,18 +422,45 @@ decodeShape le dim typeCode
 
 decodeMulti ::
   Bool ->
+  -- | outer label, e.g. @"MultiPoint"@
+  Text ->
+  -- | expected sub-geometry label, e.g. @"Point"@
+  Text ->
   (Shape -> Maybe a) ->
   ([a] -> Shape) ->
   PtrPeeker.Variable (Either Text Shape)
-decodeMulti le project ctor = do
+decodeMulti le outerLabel expectedLabel project ctor = do
   n <- readWord32 le
   subs <- replicateM (fromIntegral n) (readGeometry False)
   pure $ case sequence subs of
     Left err -> Left err
     Right pairs ->
-      case traverse (project . snd) pairs of
-        Just xs -> Right (ctor xs)
-        Nothing -> Left "geometry: MultiXxx contained a sub-geometry of the wrong shape"
+      let shapes = map snd pairs
+       in case traverse project shapes of
+            Just xs -> Right (ctor xs)
+            Nothing ->
+              let actual = maybe "unknown" shapeLabel (find (isNothing . project) shapes)
+               in Left
+                    ( "geometry: "
+                        <> outerLabel
+                        <> " contained a sub-geometry of the wrong shape (expected "
+                        <> expectedLabel
+                        <> ", got "
+                        <> actual
+                        <> ")"
+                    )
+
+-- | Short human-readable name for a 'Shape' constructor, used in decoder
+-- error messages.
+shapeLabel :: Shape -> Text
+shapeLabel = \case
+  Point {} -> "Point"
+  LineString {} -> "LineString"
+  Polygon {} -> "Polygon"
+  MultiPoint {} -> "MultiPoint"
+  MultiLineString {} -> "MultiLineString"
+  MultiPolygon {} -> "MultiPolygon"
+  GeometryCollection {} -> "GeometryCollection"
 
 readWord32 :: Bool -> PtrPeeker.Variable Word32
 readWord32 le = PtrPeeker.fixed (if le then PtrPeeker.leUnsignedInt4 else PtrPeeker.beUnsignedInt4)

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -1,48 +1,117 @@
 module PostgresqlTypes.Geometry
-  ( Geometry (..),
+  ( -- * Type
+    Geometry (..),
+    Shape (..),
+    Coord (..),
+
+    -- * Smart constructors
+    fromShape,
+    fromShapeWithSrid,
 
     -- * Accessors
-    toEWKB,
-
-    -- * Constructors
-    fromEWKB,
+    geometrySrid,
+    geometryShape,
   )
 where
 
 import qualified Data.Attoparsec.Text as Attoparsec
 import qualified Data.ByteString as ByteString
 import qualified Data.Text as Text
+import GHC.Float (castDoubleToWord64, castWord64ToDouble)
 import PostgresqlTypes.Algebra
 import PostgresqlTypes.Prelude
 import PostgresqlTypes.Via
 import qualified PtrPeeker
 import qualified PtrPoker.Write as Write
+import Test.QuickCheck (Gen, elements, listOf, listOf1, oneof, resize, sized, vectorOf)
 import qualified TextBuilder
 
--- | PostGIS @geometry@ extension type. Stores the raw
--- [EWKB](https://postgis.net/docs/using_postgis_dbmanagement.html#EWKB_EWKT)
--- bytes of a geometry value; higher-level structure (point, polygon, SRID,
--- etc.) can be decoded from those bytes in application code when needed.
+-- | PostGIS @geometry@ extension type.
 --
--- The @geometry@ type is not built into PostgreSQL: it is registered when
--- @CREATE EXTENSION postgis@ runs, and receives a different OID in each
--- database. Correspondingly 'baseOid' and 'arrayOid' are 'Nothing' — driver
--- adapters (e.g. the @hasql-postgresql-types@ adapter) resolve the OID by
--- 'typeName' at query time.
+-- A PostGIS geometry is a 'Shape' (one of 'Point', 'LineString', 'Polygon',
+-- the @Multi@ variants, or a 'GeometryCollection') together with an optional
+-- @SRID@ (spatial reference identifier). All coordinates inside a single
+-- 'Geometry' value share one dimensionality — every coordinate uses exactly
+-- the same combination of optional @z@ and @m@ ordinates. This invariant is
+-- enforced by the smart constructor 'fromShape' / 'fromShapeWithSrid'.
 --
--- Both the binary and textual formats used here match PostGIS's canonical
--- serialization:
+-- The wire format is PostGIS's
+-- [EWKB](https://postgis.net/docs/using_postgis_dbmanagement.html#EWKB_EWKT),
+-- the same binary shape PostGIS emits from @geometry_send@ and accepts in
+-- @geometry_recv@. The textual format is the upper-case hex encoding that
+-- PostGIS's @geometry_out@ produces and @geometry_in@ accepts.
 --
--- * Binary: the raw EWKB byte sequence.
--- * Textual: the upper-case hex encoding PostGIS emits from @geometry_out@
---   and accepts via @geometry_in@.
-newtype Geometry = Geometry ByteString
-  deriving newtype (Eq, Ord, Hashable)
+-- The @geometry@ type is not a built-in PostgreSQL type: it is registered at
+-- @CREATE EXTENSION postgis@ time and receives a different OID in each
+-- database. 'baseOid' and 'arrayOid' are therefore 'Nothing', and drivers
+-- resolve the OID by 'typeName' at query time.
+data Geometry
+  = -- | __Prefer 'fromShape' / 'fromShapeWithSrid'__: the constructor does
+    --   not enforce dimension consistency across nested shapes.
+    Geometry
+      -- | Spatial reference ID. Sub-geometries inside a 'GeometryCollection'
+      --   inherit this from the outer value; EWKB only stores SRID on the
+      --   top-level geometry.
+      !(Maybe Int32)
+      !Shape
+  deriving stock (Eq, Ord)
   deriving (Show, Read, IsString) via (ViaIsScalar Geometry)
 
-instance Arbitrary Geometry where
-  arbitrary = Geometry . ByteString.pack <$> arbitrary
-  shrink (Geometry bs) = Geometry . ByteString.pack <$> shrink (ByteString.unpack bs)
+-- | One of the seven PostGIS/OGC geometry shapes.
+data Shape
+  = Point !Coord
+  | -- | Zero or more coordinates forming a connected line.
+    LineString ![Coord]
+  | -- | One or more linear rings. The first ring is the exterior, the rest
+    --   are interior (holes). Each ring is a closed sequence of coordinates.
+    Polygon ![[Coord]]
+  | MultiPoint ![Coord]
+  | -- | A collection of line strings, each given as its own coordinate list.
+    MultiLineString ![[Coord]]
+  | -- | A collection of polygons, each given as its list of rings.
+    MultiPolygon ![[[Coord]]]
+  | -- | Heterogeneous collection of geometries; sub-geometries do not carry
+    --   their own SRID and must share the outer dimensionality.
+    GeometryCollection ![Shape]
+  deriving stock (Eq, Ord, Show, Read)
+
+-- | 2D, 3D (Z), 2D-with-measure (M), or 4D (Z + M) coordinate.
+--
+-- All coordinates in one 'Geometry' must have matching 'z' and 'm'
+-- @'isJust'@/@'isNothing'@ status; the smart constructor checks this.
+data Coord = Coord
+  { coordX :: !Double,
+    coordY :: !Double,
+    coordZ :: !(Maybe Double),
+    coordM :: !(Maybe Double)
+  }
+  deriving stock (Eq, Ord, Show, Read)
+
+-- * Smart constructors
+
+-- | Build a 'Geometry' with no SRID after verifying that every coordinate in
+--   the shape tree has matching 'coordZ' and 'coordM' dimensionality.
+--   Returns a 'Text' error describing the first mismatch if the shape is
+--   malformed.
+fromShape :: Shape -> Either Text Geometry
+fromShape = fromShapeWithSrid Nothing
+
+-- | Build a 'Geometry' with an SRID after the same dimension check as
+--   'fromShape'.
+fromShapeWithSrid :: Maybe Int32 -> Shape -> Either Text Geometry
+fromShapeWithSrid srid shape = do
+  void (shapeDim shape)
+  pure (Geometry srid shape)
+
+-- | Top-level SRID, if any.
+geometrySrid :: Geometry -> Maybe Int32
+geometrySrid (Geometry s _) = s
+
+-- | Top-level shape.
+geometryShape :: Geometry -> Shape
+geometryShape (Geometry _ s) = s
+
+-- * IsScalar instance
 
 instance IsScalar Geometry where
   schemaName = Tagged Nothing
@@ -50,24 +119,40 @@ instance IsScalar Geometry where
   baseOid = Tagged Nothing
   arrayOid = Tagged Nothing
   typeParams = Tagged []
-  binaryEncoder (Geometry bs) =
-    Write.byteString bs
-  binaryDecoder =
-    Right . Geometry <$> PtrPeeker.remainderAsByteString
-  textualEncoder (Geometry bs) =
-    -- 'TextBuilder.hexadecimal' on a 'Word8' produces two hex digits.
-    foldMap TextBuilder.hexadecimal (ByteString.unpack bs)
+
+  binaryEncoder (Geometry srid shape) =
+    let dim = either (const XY) id (shapeDimOrXY shape)
+     in writeGeometry True srid dim shape
+
+  binaryDecoder = do
+    res <- readGeometry True
+    pure $ case res of
+      Left err ->
+        Left
+          DecodingError
+            { location = ["geometry"],
+              reason = ParsingDecodingErrorReason err mempty
+            }
+      Right (inheritedSrid, shape) -> Right (Geometry inheritedSrid shape)
+
+  textualEncoder (Geometry srid shape) =
+    let bytes = Write.toByteString (binaryEncoder (Geometry srid shape))
+     in foldMap TextBuilder.hexadecimal (ByteString.unpack bytes)
+
   textualDecoder = do
     hexText <- Attoparsec.takeText
     case parseHexBytes hexText of
-      Left err -> fail err
-      Right bytes -> pure (Geometry bytes)
+      Left err -> fail ("geometry: " <> err)
+      Right bytes -> case PtrPeeker.runVariableOnByteString binaryDecoder bytes of
+        Left leftover -> fail ("geometry: binary decoder left " <> show leftover <> " unconsumed bytes")
+        Right (Left err) -> fail ("geometry: " <> show err)
+        Right (Right value) -> pure value
     where
       parseHexBytes :: Text -> Either String ByteString
       parseHexBytes t = ByteString.pack <$> parseHexPairs (Text.unpack t)
       parseHexPairs :: [Char] -> Either String [Word8]
       parseHexPairs [] = Right []
-      parseHexPairs [_] = Left "Odd number of hex digits"
+      parseHexPairs [_] = Left "odd number of hex digits"
       parseHexPairs (a : b : rest) = do
         byte <- hexPairToByte a b
         (byte :) <$> parseHexPairs rest
@@ -81,16 +166,279 @@ instance IsScalar Geometry where
         | c >= '0' && c <= '9' = Right (fromIntegral (ord c - ord '0'))
         | c >= 'a' && c <= 'f' = Right (fromIntegral (ord c - ord 'a' + 10))
         | c >= 'A' && c <= 'F' = Right (fromIntegral (ord c - ord 'A' + 10))
-        | otherwise = Left ("Invalid hex digit: " ++ [c])
+        | otherwise = Left ("invalid hex digit: " ++ [c])
 
--- * Accessors
+-- * Arbitrary / Hashable
 
--- | Extract the raw EWKB 'ByteString'.
-toEWKB :: Geometry -> ByteString
-toEWKB (Geometry bs) = bs
+instance Hashable Geometry where
+  hashWithSalt salt (Geometry s shape) =
+    salt `hashWithSalt` s `hashWithSalt` showsPrec 0 shape ""
 
--- * Constructors
+instance Arbitrary Geometry where
+  arbitrary = do
+    srid <- oneof [pure Nothing, Just <$> arbitrary]
+    dim <- elements [XY, XYZ, XYM, XYZM]
+    shape <- sized (shapeGen dim)
+    pure (Geometry srid shape)
+  shrink (Geometry srid shape) =
+    [Geometry srid' shape | srid' <- shrink srid]
 
--- | Wrap a raw EWKB 'ByteString' as a PostGIS 'Geometry' value.
-fromEWKB :: ByteString -> Geometry
-fromEWKB = Geometry
+-- * Dimension handling
+
+data Dim = XY | XYZ | XYM | XYZM
+  deriving stock (Eq, Show)
+
+dimOfCoord :: Coord -> Dim
+dimOfCoord (Coord _ _ Nothing Nothing) = XY
+dimOfCoord (Coord _ _ (Just _) Nothing) = XYZ
+dimOfCoord (Coord _ _ Nothing (Just _)) = XYM
+dimOfCoord (Coord _ _ (Just _) (Just _)) = XYZM
+
+-- | Recursively determine the dimension of a shape, failing if the tree
+-- contains inconsistent coordinates. Returns 'Nothing' when no coordinates
+-- are present (e.g. an empty @LineString@); callers default those to 'XY'.
+shapeDim :: Shape -> Either Text (Maybe Dim)
+shapeDim = go Nothing
+  where
+    go :: Maybe Dim -> Shape -> Either Text (Maybe Dim)
+    go acc = \case
+      Point c -> Just <$> combine acc (dimOfCoord c)
+      LineString cs -> foldCoords acc cs
+      Polygon rings -> foldM goRing acc rings
+      MultiPoint cs -> foldCoords acc cs
+      MultiLineString lss -> foldM foldCoords acc lss
+      MultiPolygon polys -> foldM (foldM goRing) acc polys
+      GeometryCollection shapes -> foldM go acc shapes
+    goRing :: Maybe Dim -> [Coord] -> Either Text (Maybe Dim)
+    goRing = foldCoords
+    foldCoords :: Maybe Dim -> [Coord] -> Either Text (Maybe Dim)
+    foldCoords = foldM (\a c -> Just <$> combine a (dimOfCoord c))
+    combine :: Maybe Dim -> Dim -> Either Text Dim
+    combine Nothing d = Right d
+    combine (Just d) d'
+      | d == d' = Right d
+      | otherwise =
+          Left
+            ( "geometry: inconsistent coordinate dimensions — got "
+                <> Text.pack (show d')
+                <> " after "
+                <> Text.pack (show d)
+            )
+
+shapeDimOrXY :: Shape -> Either Text Dim
+shapeDimOrXY = fmap (fromMaybe XY) . shapeDim
+
+-- * Type codes and flag bits
+
+typeCodePoint, typeCodeLineString, typeCodePolygon :: Word32
+typeCodeMultiPoint, typeCodeMultiLineString, typeCodeMultiPolygon :: Word32
+typeCodeGeometryCollection :: Word32
+typeCodePoint = 1
+typeCodeLineString = 2
+typeCodePolygon = 3
+typeCodeMultiPoint = 4
+typeCodeMultiLineString = 5
+typeCodeMultiPolygon = 6
+typeCodeGeometryCollection = 7
+
+flagZ, flagM, flagSRID :: Word32
+flagZ = 0x80000000
+flagM = 0x40000000
+flagSRID = 0x20000000
+
+dimFlags :: Dim -> Word32
+dimFlags XY = 0
+dimFlags XYZ = flagZ
+dimFlags XYM = flagM
+dimFlags XYZM = flagZ .|. flagM
+
+typeCodeOfShape :: Shape -> Word32
+typeCodeOfShape = \case
+  Point {} -> typeCodePoint
+  LineString {} -> typeCodeLineString
+  Polygon {} -> typeCodePolygon
+  MultiPoint {} -> typeCodeMultiPoint
+  MultiLineString {} -> typeCodeMultiLineString
+  MultiPolygon {} -> typeCodeMultiPolygon
+  GeometryCollection {} -> typeCodeGeometryCollection
+
+-- * Binary encoder
+
+-- | Encode a geometry as EWKB. The @topLevel@ flag controls whether the SRID
+--   flag and value are emitted — sub-geometries within Multi* / Collection
+--   values inherit the outer SRID and do not repeat it.
+writeGeometry :: Bool -> Maybe Int32 -> Dim -> Shape -> Write.Write
+writeGeometry topLevel srid dim shape =
+  let sridFlag = if topLevel && isJust srid then flagSRID else 0
+      header = lWord32 (typeCodeOfShape shape .|. dimFlags dim .|. sridFlag)
+      sridField = case (topLevel, srid) of
+        (True, Just s) -> lWord32 (fromIntegral s)
+        _ -> mempty
+   in Write.word8 0x01 -- little-endian / NDR byte order
+        <> header
+        <> sridField
+        <> writePayload dim shape
+
+-- | Little-endian Word32 encode helper (alias to keep the caller readable).
+lWord32 :: Word32 -> Write.Write
+lWord32 = Write.lWord32
+
+lWord64 :: Word64 -> Write.Write
+lWord64 = Write.lWord64
+
+writePayload :: Dim -> Shape -> Write.Write
+writePayload dim = \case
+  Point c -> writeCoord dim c
+  LineString cs -> lWord32 (fromIntegral (length cs)) <> foldMap (writeCoord dim) cs
+  Polygon rings -> lWord32 (fromIntegral (length rings)) <> foldMap (writeRing dim) rings
+  MultiPoint cs ->
+    lWord32 (fromIntegral (length cs))
+      <> foldMap (writeGeometry False Nothing dim . Point) cs
+  MultiLineString lss ->
+    lWord32 (fromIntegral (length lss))
+      <> foldMap (writeGeometry False Nothing dim . LineString) lss
+  MultiPolygon polys ->
+    lWord32 (fromIntegral (length polys))
+      <> foldMap (writeGeometry False Nothing dim . Polygon) polys
+  GeometryCollection shapes ->
+    lWord32 (fromIntegral (length shapes))
+      <> foldMap (writeGeometry False Nothing dim) shapes
+
+writeRing :: Dim -> [Coord] -> Write.Write
+writeRing dim cs = lWord32 (fromIntegral (length cs)) <> foldMap (writeCoord dim) cs
+
+writeCoord :: Dim -> Coord -> Write.Write
+writeCoord dim (Coord x y mz mm) =
+  lWord64 (castDoubleToWord64 x)
+    <> lWord64 (castDoubleToWord64 y)
+    <> (case dim of XYZ -> lWord64 (castDoubleToWord64 (fromMaybe 0 mz)); XYZM -> lWord64 (castDoubleToWord64 (fromMaybe 0 mz)); _ -> mempty)
+    <> (case dim of XYM -> lWord64 (castDoubleToWord64 (fromMaybe 0 mm)); XYZM -> lWord64 (castDoubleToWord64 (fromMaybe 0 mm)); _ -> mempty)
+
+-- * Binary decoder
+
+-- | Decoder result: inherited SRID (top-level only) plus the decoded shape.
+--   Sub-geometries do not produce an SRID; their value is 'Nothing'.
+readGeometry :: Bool -> PtrPeeker.Variable (Either Text (Maybe Int32, Shape))
+readGeometry topLevel = do
+  byteOrderFlag <- PtrPeeker.fixed PtrPeeker.unsignedInt1
+  let littleEndian = byteOrderFlag /= 0
+  typeWithFlags <- readWord32 littleEndian
+  let hasZ = testBit typeWithFlags 31
+      hasM = testBit typeWithFlags 30
+      hasSRID = testBit typeWithFlags 29
+      rawType = typeWithFlags .&. 0x1FFFFFFF
+      dim = case (hasZ, hasM) of
+        (False, False) -> XY
+        (True, False) -> XYZ
+        (False, True) -> XYM
+        (True, True) -> XYZM
+  srid <-
+    if hasSRID && topLevel
+      then Just . (fromIntegral :: Word32 -> Int32) <$> readWord32 littleEndian
+      else
+        if hasSRID
+          then Just . (fromIntegral :: Word32 -> Int32) <$> readWord32 littleEndian
+          else pure Nothing
+  result <- decodeShape littleEndian dim rawType
+  pure $ case result of
+    Left err -> Left err
+    Right shape -> Right (if topLevel then srid else Nothing, shape)
+
+decodeShape :: Bool -> Dim -> Word32 -> PtrPeeker.Variable (Either Text Shape)
+decodeShape le dim typeCode
+  | typeCode == typeCodePoint = do
+      c <- readCoord le dim
+      pure (Right (Point c))
+  | typeCode == typeCodeLineString = do
+      n <- readWord32 le
+      cs <- replicateM (fromIntegral n) (readCoord le dim)
+      pure (Right (LineString cs))
+  | typeCode == typeCodePolygon = do
+      nRings <- readWord32 le
+      rings <- replicateM (fromIntegral nRings) $ do
+        np <- readWord32 le
+        replicateM (fromIntegral np) (readCoord le dim)
+      pure (Right (Polygon rings))
+  | typeCode == typeCodeMultiPoint = decodeMulti le (\case Point c -> Just c; _ -> Nothing) MultiPoint
+  | typeCode == typeCodeMultiLineString = decodeMulti le (\case LineString cs -> Just cs; _ -> Nothing) MultiLineString
+  | typeCode == typeCodeMultiPolygon = decodeMulti le (\case Polygon rings -> Just rings; _ -> Nothing) MultiPolygon
+  | typeCode == typeCodeGeometryCollection = do
+      n <- readWord32 le
+      subs <- replicateM (fromIntegral n) (readGeometry False)
+      pure $ case sequence subs of
+        Left err -> Left err
+        Right pairs -> Right (GeometryCollection (map snd pairs))
+  | otherwise = pure (Left ("geometry: unsupported type code " <> Text.pack (show typeCode)))
+
+decodeMulti ::
+  Bool ->
+  (Shape -> Maybe a) ->
+  ([a] -> Shape) ->
+  PtrPeeker.Variable (Either Text Shape)
+decodeMulti le project ctor = do
+  n <- readWord32 le
+  subs <- replicateM (fromIntegral n) (readGeometry False)
+  pure $ case sequence subs of
+    Left err -> Left err
+    Right pairs ->
+      case traverse (project . snd) pairs of
+        Just xs -> Right (ctor xs)
+        Nothing -> Left "geometry: MultiXxx contained a sub-geometry of the wrong shape"
+
+readWord32 :: Bool -> PtrPeeker.Variable Word32
+readWord32 le = PtrPeeker.fixed (if le then PtrPeeker.leUnsignedInt4 else PtrPeeker.beUnsignedInt4)
+
+readWord64 :: Bool -> PtrPeeker.Variable Word64
+readWord64 le = PtrPeeker.fixed (if le then PtrPeeker.leUnsignedInt8 else PtrPeeker.beUnsignedInt8)
+
+readDouble :: Bool -> PtrPeeker.Variable Double
+readDouble le = castWord64ToDouble <$> readWord64 le
+
+readCoord :: Bool -> Dim -> PtrPeeker.Variable Coord
+readCoord le dim = do
+  x <- readDouble le
+  y <- readDouble le
+  (z, m) <- case dim of
+    XY -> pure (Nothing, Nothing)
+    XYZ -> do z <- readDouble le; pure (Just z, Nothing)
+    XYM -> do m <- readDouble le; pure (Nothing, Just m)
+    XYZM -> do z <- readDouble le; m <- readDouble le; pure (Just z, Just m)
+  pure (Coord x y z m)
+
+-- * QuickCheck generators
+
+shapeGen :: Dim -> Int -> Gen Shape
+shapeGen dim n
+  | n <= 1 =
+      oneof
+        [ Point <$> coordGen dim,
+          LineString <$> vectorOf 2 (coordGen dim),
+          singleRingPolygonGen dim,
+          MultiPoint <$> listOf (coordGen dim)
+        ]
+  | otherwise =
+      oneof
+        [ Point <$> coordGen dim,
+          LineString <$> listOf1 (coordGen dim),
+          singleRingPolygonGen dim,
+          MultiPoint <$> listOf (coordGen dim),
+          MultiLineString <$> listOf (listOf1 (coordGen dim)),
+          MultiPolygon <$> listOf (listOf1 (listOf1 (coordGen dim))),
+          GeometryCollection <$> resize (n `div` 4) (listOf (shapeGen dim (n `div` 4)))
+        ]
+
+singleRingPolygonGen :: Dim -> Gen Shape
+singleRingPolygonGen dim = do
+  ring <- vectorOf 4 (coordGen dim)
+  pure (Polygon [ring])
+
+coordGen :: Dim -> Gen Coord
+coordGen dim = do
+  x <- arbitrary
+  y <- arbitrary
+  (z, m) <- case dim of
+    XY -> pure (Nothing, Nothing)
+    XYZ -> (,) <$> (Just <$> arbitrary) <*> pure Nothing
+    XYM -> (,) Nothing . Just <$> arbitrary
+    XYZM -> (,) <$> (Just <$> arbitrary) <*> (Just <$> arbitrary)
+  pure (Coord x y z m)

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -167,16 +167,21 @@ instance Hashable Geometry where
 
 instance Arbitrary Geometry where
   arbitrary = do
-    -- PostGIS treats @SRID = 0@ as "no SRID" and drops the SRID flag on
-    -- output, so @SRID 0@ doesn't round-trip exactly. Stick to the
-    -- positive half of 'Int32' — which is where real EPSG / spatial_ref_sys
-    -- codes live — so wire-format round-trip is an equality.
-    srid <- oneof [pure Nothing, Just <$> choose (1, maxBound)]
+    -- PostGIS clamps SRID values that fall outside its documented
+    -- user-assignable range — SRID 0 becomes "no SRID" (drops the SRID
+    -- flag on output), and SRIDs above @SRID_USER_MAXIMUM = 998_999@ get
+    -- modulo-remapped into the reserved internal range. Stick to
+    -- @[1, 998_999]@ — which is where real EPSG / spatial_ref_sys codes
+    -- live — so wire-format round-trip is an equality.
+    srid <- oneof [pure Nothing, Just <$> choose (1, 998_999)]
     dim <- elements [XY, XYZ, XYM, XYZM]
     shape <- sized (shapeGen dim)
     pure (Geometry srid shape)
   shrink (Geometry srid shape) =
-    [Geometry srid' shape | srid' <- shrink srid, maybe True (> 0) srid']
+    [ Geometry srid' shape
+      | srid' <- shrink srid,
+        maybe True (\s -> s > 0 && s <= 998_999) srid'
+    ]
 
 -- * Dimension handling
 

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -109,8 +109,16 @@ instance IsScalar Geometry where
   typeParams = Tagged []
 
   binaryEncoder (Geometry srid shape) =
-    let dim = either (const XY) id (shapeDimOrXY shape)
-     in writeGeometry True srid dim shape
+    -- The raw constructor can be used to build a 'Geometry' whose shape
+    -- tree mixes XY, XYZ, XYM and XYZM coords. 'binaryEncoder' is
+    -- partial on such values — silently falling back to XY would drop
+    -- the Z and M ordinates and produce a byte sequence that doesn't
+    -- round-trip. Callers are expected to construct via 'fromShape' /
+    -- 'fromShapeWithSrid' (which reject this case).
+    case shapeDimOrXY shape of
+      Right dim -> writeGeometry True srid dim shape
+      Left err ->
+        error ("PostgresqlTypes.Geometry.binaryEncoder: " <> Text.unpack err)
 
   binaryDecoder = do
     res <- readGeometry True
@@ -333,7 +341,23 @@ includesM _ = False
 readGeometry :: Bool -> PtrPeeker.Variable (Either Text (Maybe Int32, Shape))
 readGeometry topLevel = do
   byteOrderFlag <- PtrPeeker.fixed PtrPeeker.unsignedInt1
-  let littleEndian = byteOrderFlag /= 0
+  -- EWKB specifies only 0 (XDR / big-endian) and 1 (NDR / little-endian);
+  -- any other value indicates garbage input, so reject loudly rather than
+  -- silently accepting it as little-endian.
+  case byteOrderFlag of
+    0 -> readGeometryBody topLevel False
+    1 -> readGeometryBody topLevel True
+    other ->
+      pure
+        ( Left
+            ( "geometry: invalid EWKB byte-order marker "
+                <> Text.pack (show other)
+                <> " (expected 0 or 1)"
+            )
+        )
+
+readGeometryBody :: Bool -> Bool -> PtrPeeker.Variable (Either Text (Maybe Int32, Shape))
+readGeometryBody topLevel littleEndian = do
   typeWithFlags <- readWord32 littleEndian
   let hasZ = testBit typeWithFlags 31
       hasM = testBit typeWithFlags 30

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -140,10 +140,18 @@ instance IsScalar Geometry where
     case parseHexBytes hexText of
       Left err -> fail ("geometry: " <> err)
       Right bytes -> case PtrPeeker.runVariableOnByteString binaryDecoder bytes of
-        -- 'runVariableOnByteString' reports the leftover as an 'Int' byte
-        -- count, not the bytes themselves, so it is safe to include
-        -- verbatim in the error message.
-        Left leftover -> fail ("geometry: binary decoder left " <> show leftover <> " unconsumed bytes")
+        Left leftover ->
+          let total = ByteString.length bytes
+              consumed = total - leftover
+           in fail
+                ( "geometry: binary decoder stopped after "
+                    <> show consumed
+                    <> " of "
+                    <> show total
+                    <> " bytes ("
+                    <> show leftover
+                    <> " unconsumed)"
+                )
         Right (Left err) -> fail ("geometry: " <> show err)
         Right (Right value) -> pure value
     where
@@ -181,7 +189,10 @@ instance Hashable Geometry where
       Right _ ->
         salt `hashWithSalt` Write.toByteString (binaryEncoder geom)
       Left dimErr ->
-        salt `hashWithSalt` srid `hashWithSalt` dimErr
+        salt
+          `hashWithSalt` srid
+          `hashWithSalt` dimErr
+          `hashWithSalt` Text.pack (show shape)
 
 instance Arbitrary Geometry where
   arbitrary = do
@@ -407,11 +418,11 @@ decodeShape le dim typeCode
         replicateM (fromIntegral np) (readCoord le dim)
       pure (Right (Polygon rings))
   | typeCode == typeCodeMultiPoint =
-      decodeMulti le "MultiPoint" "Point" (\case Point c -> Just c; _ -> Nothing) MultiPoint
+      decodeMulti le "Point" (\case Point c -> Just c; _ -> Nothing) MultiPoint
   | typeCode == typeCodeMultiLineString =
-      decodeMulti le "MultiLineString" "LineString" (\case LineString cs -> Just cs; _ -> Nothing) MultiLineString
+      decodeMulti le "LineString" (\case LineString cs -> Just cs; _ -> Nothing) MultiLineString
   | typeCode == typeCodeMultiPolygon =
-      decodeMulti le "MultiPolygon" "Polygon" (\case Polygon rings -> Just rings; _ -> Nothing) MultiPolygon
+      decodeMulti le "Polygon" (\case Polygon rings -> Just rings; _ -> Nothing) MultiPolygon
   | typeCode == typeCodeGeometryCollection = do
       n <- readWord32 le
       subs <- replicateM (fromIntegral n) (readGeometry False)
@@ -422,20 +433,21 @@ decodeShape le dim typeCode
 
 decodeMulti ::
   Bool ->
-  -- | outer label, e.g. @"MultiPoint"@
-  Text ->
-  -- | expected sub-geometry label, e.g. @"Point"@
+  -- | expected sub-geometry label, e.g. @"Point"@. The outer label is
+  --   derived from @ctor []@ so call sites can't drift out of sync with
+  --   the constructor they pass.
   Text ->
   (Shape -> Maybe a) ->
   ([a] -> Shape) ->
   PtrPeeker.Variable (Either Text Shape)
-decodeMulti le outerLabel expectedLabel project ctor = do
+decodeMulti le expectedLabel project ctor = do
   n <- readWord32 le
   subs <- replicateM (fromIntegral n) (readGeometry False)
   pure $ case sequence subs of
     Left err -> Left err
     Right pairs ->
       let shapes = map snd pairs
+          outerLabel = shapeLabel (ctor [])
        in case traverse project shapes of
             Just xs -> Right (ctor xs)
             Nothing ->

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -1,0 +1,96 @@
+module PostgresqlTypes.Geometry
+  ( Geometry (..),
+
+    -- * Accessors
+    toEWKB,
+
+    -- * Constructors
+    fromEWKB,
+  )
+where
+
+import qualified Data.Attoparsec.Text as Attoparsec
+import qualified Data.ByteString as ByteString
+import qualified Data.Text as Text
+import PostgresqlTypes.Algebra
+import PostgresqlTypes.Prelude
+import PostgresqlTypes.Via
+import qualified PtrPeeker
+import qualified PtrPoker.Write as Write
+import qualified TextBuilder
+
+-- | PostGIS @geometry@ extension type. Stores the raw
+-- [EWKB](https://postgis.net/docs/using_postgis_dbmanagement.html#EWKB_EWKT)
+-- bytes of a geometry value; higher-level structure (point, polygon, SRID,
+-- etc.) can be decoded from those bytes in application code when needed.
+--
+-- The @geometry@ type is not built into PostgreSQL: it is registered when
+-- @CREATE EXTENSION postgis@ runs, and receives a different OID in each
+-- database. Correspondingly 'baseOid' and 'arrayOid' are 'Nothing' — driver
+-- adapters (e.g. the @hasql-postgresql-types@ adapter) resolve the OID by
+-- 'typeName' at query time.
+--
+-- Both the binary and textual formats used here match PostGIS's canonical
+-- serialization:
+--
+-- * Binary: the raw EWKB byte sequence.
+-- * Textual: the upper-case hex encoding PostGIS emits from @geometry_out@
+--   and accepts via @geometry_in@.
+newtype Geometry = Geometry ByteString
+  deriving newtype (Eq, Ord, Hashable)
+  deriving (Show, Read, IsString) via (ViaIsScalar Geometry)
+
+instance Arbitrary Geometry where
+  arbitrary = Geometry . ByteString.pack <$> arbitrary
+  shrink (Geometry bs) = Geometry . ByteString.pack <$> shrink (ByteString.unpack bs)
+
+instance IsScalar Geometry where
+  schemaName = Tagged Nothing
+  typeName = Tagged "geometry"
+  baseOid = Tagged Nothing
+  arrayOid = Tagged Nothing
+  typeParams = Tagged []
+  binaryEncoder (Geometry bs) =
+    Write.byteString bs
+  binaryDecoder =
+    Right . Geometry <$> PtrPeeker.remainderAsByteString
+  textualEncoder (Geometry bs) =
+    -- 'TextBuilder.hexadecimal' on a 'Word8' produces two hex digits.
+    foldMap TextBuilder.hexadecimal (ByteString.unpack bs)
+  textualDecoder = do
+    hexText <- Attoparsec.takeText
+    case parseHexBytes hexText of
+      Left err -> fail err
+      Right bytes -> pure (Geometry bytes)
+    where
+      parseHexBytes :: Text -> Either String ByteString
+      parseHexBytes t = ByteString.pack <$> parseHexPairs (Text.unpack t)
+      parseHexPairs :: [Char] -> Either String [Word8]
+      parseHexPairs [] = Right []
+      parseHexPairs [_] = Left "Odd number of hex digits"
+      parseHexPairs (a : b : rest) = do
+        byte <- hexPairToByte a b
+        (byte :) <$> parseHexPairs rest
+      hexPairToByte :: Char -> Char -> Either String Word8
+      hexPairToByte a b = do
+        high <- hexDigitToWord8 a
+        low <- hexDigitToWord8 b
+        pure (high * 16 + low)
+      hexDigitToWord8 :: Char -> Either String Word8
+      hexDigitToWord8 c
+        | c >= '0' && c <= '9' = Right (fromIntegral (ord c - ord '0'))
+        | c >= 'a' && c <= 'f' = Right (fromIntegral (ord c - ord 'a' + 10))
+        | c >= 'A' && c <= 'F' = Right (fromIntegral (ord c - ord 'A' + 10))
+        | otherwise = Left ("Invalid hex digit: " ++ [c])
+
+-- * Accessors
+
+-- | Extract the raw EWKB 'ByteString'.
+toEWKB :: Geometry -> ByteString
+toEWKB (Geometry bs) = bs
+
+-- * Constructors
+
+-- | Wrap a raw EWKB 'ByteString' as a PostGIS 'Geometry' value.
+fromEWKB :: ByteString -> Geometry
+fromEWKB = Geometry

--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -19,7 +19,7 @@ import PostgresqlTypes.Prelude
 import PostgresqlTypes.Via
 import qualified PtrPeeker
 import qualified PtrPoker.Write as Write
-import Test.QuickCheck (Gen, elements, listOf, listOf1, oneof, resize, sized, vectorOf)
+import Test.QuickCheck (Gen, choose, elements, listOf, listOf1, oneof, resize, sized, vectorOf)
 import qualified TextBuilder
 
 -- | PostGIS @geometry@ extension type.
@@ -159,8 +159,11 @@ instance IsScalar Geometry where
 -- * Arbitrary / Hashable
 
 instance Hashable Geometry where
-  hashWithSalt salt (Geometry s shape) =
-    salt `hashWithSalt` s `hashWithSalt` showsPrec 0 shape ""
+  -- Hash via the canonical EWKB bytes so two equal 'Geometry' values always
+  -- hash the same, independent of any structural irrelevance. The
+  -- binaryEncoder is bit-stable.
+  hashWithSalt salt geom =
+    salt `hashWithSalt` Write.toByteString (binaryEncoder geom)
 
 instance Arbitrary Geometry where
   arbitrary = do
@@ -297,10 +300,22 @@ writeRing dim cs = lWord32 (fromIntegral (length cs)) <> foldMap (writeCoord dim
 
 writeCoord :: Dim -> Coord -> Write.Write
 writeCoord dim (Coord x y mz mm) =
-  lWord64 (castDoubleToWord64 x)
-    <> lWord64 (castDoubleToWord64 y)
-    <> (case dim of XYZ -> lWord64 (castDoubleToWord64 (fromMaybe 0 mz)); XYZM -> lWord64 (castDoubleToWord64 (fromMaybe 0 mz)); _ -> mempty)
-    <> (case dim of XYM -> lWord64 (castDoubleToWord64 (fromMaybe 0 mm)); XYZM -> lWord64 (castDoubleToWord64 (fromMaybe 0 mm)); _ -> mempty)
+  encodeDouble x
+    <> encodeDouble y
+    <> (if includesZ dim then encodeDouble (fromMaybe 0 mz) else mempty)
+    <> (if includesM dim then encodeDouble (fromMaybe 0 mm) else mempty)
+  where
+    encodeDouble = lWord64 . castDoubleToWord64
+
+includesZ :: Dim -> Bool
+includesZ XYZ = True
+includesZ XYZM = True
+includesZ _ = False
+
+includesM :: Dim -> Bool
+includesM XYM = True
+includesM XYZM = True
+includesM _ = False
 
 -- * Binary decoder
 
@@ -320,13 +335,14 @@ readGeometry topLevel = do
         (True, False) -> XYZ
         (False, True) -> XYM
         (True, True) -> XYZM
+  -- EWKB allows sub-geometries to carry their own SRID field, but PostGIS
+  -- ignores them and inherits from the outer geometry. We consume the bytes
+  -- to keep the stream aligned, then discard the value when we're not at
+  -- the top level.
   srid <-
-    if hasSRID && topLevel
+    if hasSRID
       then Just . (fromIntegral :: Word32 -> Int32) <$> readWord32 littleEndian
-      else
-        if hasSRID
-          then Just . (fromIntegral :: Word32 -> Int32) <$> readWord32 littleEndian
-          else pure Nothing
+      else pure Nothing
   result <- decodeShape littleEndian dim rawType
   pure $ case result of
     Left err -> Left err
@@ -395,30 +411,49 @@ readCoord le dim = do
 
 -- * QuickCheck generators
 
+-- | Generates EWKB-valid 'Shape' values:
+--
+-- * 'LineString' has at least 2 coordinates.
+-- * 'Polygon' rings are closed (@first == last@) with at least 4 coordinates.
+-- * 'MultiLineString' / 'MultiPolygon' sub-items respect the same rules.
 shapeGen :: Dim -> Int -> Gen Shape
 shapeGen dim n
   | n <= 1 =
       oneof
         [ Point <$> coordGen dim,
-          LineString <$> vectorOf 2 (coordGen dim),
+          LineString <$> lineStringCoords dim,
           singleRingPolygonGen dim,
           MultiPoint <$> listOf (coordGen dim)
         ]
   | otherwise =
       oneof
         [ Point <$> coordGen dim,
-          LineString <$> listOf1 (coordGen dim),
+          LineString <$> lineStringCoords dim,
           singleRingPolygonGen dim,
           MultiPoint <$> listOf (coordGen dim),
-          MultiLineString <$> listOf (listOf1 (coordGen dim)),
-          MultiPolygon <$> listOf (listOf1 (listOf1 (coordGen dim))),
+          MultiLineString <$> listOf (lineStringCoords dim),
+          MultiPolygon <$> listOf (listOf1 (polygonRingCoords dim)),
           GeometryCollection <$> resize (n `div` 4) (listOf (shapeGen dim (n `div` 4)))
         ]
 
+lineStringCoords :: Dim -> Gen [Coord]
+lineStringCoords dim = do
+  -- OGC requires LineString to have at least 2 coordinates.
+  extra <- choose (0, 6 :: Int)
+  vectorOf (2 + extra) (coordGen dim)
+
+polygonRingCoords :: Dim -> Gen [Coord]
+polygonRingCoords dim = do
+  -- A ring is closed (first == last) and has at least 4 coordinates
+  -- (3 distinct + the closing repeat of the first).
+  extra <- choose (0, 5 :: Int)
+  interior <- vectorOf (3 + extra) (coordGen dim)
+  case interior of
+    (first : _) -> pure (interior ++ [first])
+    [] -> error "polygonRingCoords: impossible — vectorOf with positive length returned []"
+
 singleRingPolygonGen :: Dim -> Gen Shape
-singleRingPolygonGen dim = do
-  ring <- vectorOf 4 (coordGen dim)
-  pure (Polygon [ring])
+singleRingPolygonGen dim = Polygon . (: []) <$> polygonRingCoords dim
 
 coordGen :: Dim -> Gen Coord
 coordGen dim = do

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -1,7 +1,9 @@
 module PostgresqlTypes.GeometrySpec (spec) where
 
+import Control.Exception (evaluate)
 import Data.Data (Proxy (Proxy))
 import Data.Either (isLeft)
+import Data.Hashable (hashWithSalt)
 import qualified PostgresqlTypes.Geometry as Geometry
 import PostgresqlTypes.Geometry (Coord (Coord), Geometry (Geometry), Shape (..))
 import Test.Hspec
@@ -75,6 +77,32 @@ spec = do
       let cs = [Coord 0 0 (Just 1) (Just 2), Coord 3 4 (Just 5) (Just 6)]
           g = Geometry (Just 4326) (LineString cs)
       read (show g) `shouldBe` g
+
+  describe "Hashable" do
+    it "hashWithSalt is total on malformed geometries" do
+      -- Mixed XY / XYZ coords bypass fromShape, so binaryEncoder would
+      -- call 'error'. Verify hashWithSalt routes around that.
+      let malformed =
+            Geometry
+              Nothing
+              (LineString [Coord 0 0 Nothing Nothing, Coord 1 1 (Just 2) Nothing])
+      _ <- evaluate (hashWithSalt 0 malformed)
+      pure ()
+
+    it "hashWithSalt distinguishes structurally different malformed shapes" do
+      let a =
+            Geometry
+              Nothing
+              (LineString [Coord 0 0 Nothing Nothing, Coord 1 1 (Just 2) Nothing])
+          b =
+            Geometry
+              Nothing
+              (LineString [Coord 5 5 Nothing Nothing, Coord 9 9 (Just 3) Nothing])
+      hashWithSalt 0 a `shouldNotBe` hashWithSalt 0 b
+
+    it "hashWithSalt is deterministic for well-formed geometries" do
+      let g = Geometry (Just 4326) (Point (Coord 1 2 Nothing Nothing))
+      hashWithSalt 0 g `shouldBe` hashWithSalt 0 g
 
   describe "Property: full binary roundtrip for arbitrary geometries" do
     it "holds for arbitrary shapes and SRIDs" $

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -1,46 +1,83 @@
 module PostgresqlTypes.GeometrySpec (spec) where
 
-import qualified Data.ByteString as ByteString
 import Data.Data (Proxy (Proxy))
+import Data.Either (isLeft)
 import qualified PostgresqlTypes.Geometry as Geometry
+import PostgresqlTypes.Geometry (Coord (Coord), Geometry (Geometry), Shape (..))
 import Test.Hspec
 import Test.QuickCheck
+import Data.String (fromString)
 import Test.QuickCheck.Instances ()
 import qualified UnitTests.Scripts as Scripts
+import Prelude
 
 spec :: Spec
 spec = do
   describe "Show/Read laws" do
-    Scripts.testShowRead (Proxy @Geometry.Geometry)
+    Scripts.testShowRead (Proxy @Geometry)
 
   describe "IsScalar laws" do
-    Scripts.testIsScalar (Proxy @Geometry.Geometry)
+    Scripts.testIsScalar (Proxy @Geometry)
 
-  describe "Constructors" do
-    describe "fromEWKB" do
-      it "wraps a ByteString of EWKB bytes" do
-        let bs = ByteString.pack [0x01, 0x01, 0x00, 0x00, 0x00]
-            geom = Geometry.fromEWKB bs
-        Geometry.toEWKB geom `shouldBe` bs
+  describe "Smart constructors" do
+    describe "fromShape" do
+      it "accepts an XY Point" do
+        Geometry.fromShape (Point (Coord 1 2 Nothing Nothing))
+          `shouldBe` Right (Geometry Nothing (Point (Coord 1 2 Nothing Nothing)))
 
-      it "accepts the empty ByteString" do
-        Geometry.toEWKB (Geometry.fromEWKB ByteString.empty) `shouldBe` ByteString.empty
+      it "accepts a consistently-dimensioned LineString" do
+        let cs = [Coord 0 0 (Just 1) Nothing, Coord 1 1 (Just 2) Nothing]
+        Geometry.fromShape (LineString cs)
+          `shouldBe` Right (Geometry Nothing (LineString cs))
 
-      it "preserves binary data without mangling it" do
-        let bs = ByteString.pack [0, 255, 128, 1, 127]
-        Geometry.toEWKB (Geometry.fromEWKB bs) `shouldBe` bs
+      it "rejects a LineString mixing XY and XYZ coordinates" do
+        let cs = [Coord 0 0 Nothing Nothing, Coord 1 1 (Just 2) Nothing]
+        Geometry.fromShape (LineString cs) `shouldSatisfy` isLeft
+
+      it "rejects a GeometryCollection mixing XY and XYM shapes" do
+        let mixed =
+              GeometryCollection
+                [ Point (Coord 0 0 Nothing Nothing),
+                  Point (Coord 1 1 Nothing (Just 3))
+                ]
+        Geometry.fromShape mixed `shouldSatisfy` isLeft
+
+    describe "fromShapeWithSrid" do
+      it "threads the SRID through to the Geometry value" do
+        let srid = Just 4326
+            shape = Point (Coord 13.4 52.5 Nothing Nothing)
+        Geometry.fromShapeWithSrid srid shape
+          `shouldBe` Right (Geometry srid shape)
 
   describe "Accessors" do
-    describe "toEWKB" do
-      it "extracts the underlying ByteString" do
-        let bs = ByteString.pack [10, 20, 30]
-        Geometry.toEWKB (Geometry.fromEWKB bs) `shouldBe` bs
+    it "geometrySrid extracts the SRID" do
+      Geometry.geometrySrid (Geometry (Just 4326) (Point (Coord 0 0 Nothing Nothing)))
+        `shouldBe` Just 4326
 
-  describe "Property Tests" do
-    it "roundtrips through toEWKB and fromEWKB" do
-      property \(bs :: ByteString.ByteString) ->
-        Geometry.toEWKB (Geometry.fromEWKB bs) === bs
+    it "geometryShape extracts the Shape" do
+      let shape = Point (Coord 1 2 Nothing Nothing)
+      Geometry.geometryShape (Geometry Nothing shape) `shouldBe` shape
 
-    it "roundtrips through fromEWKB and toEWKB" do
-      property \(geom :: Geometry.Geometry) ->
-        Geometry.fromEWKB (Geometry.toEWKB geom) === geom
+  describe "Binary wire format" do
+    it "decodes a canonical PostGIS EWKB Point(1,2) with SRID 4326" do
+      -- Hex from PostGIS: SELECT ST_AsEWKB(ST_SetSRID(ST_MakePoint(1, 2), 4326));
+      -- byte-order NDR (01) + type 1 with SRID flag (01000020) + SRID 4326 (E6100000)
+      --   + x=1.0 (000000000000F03F) + y=2.0 (0000000000000040)
+      let hex = "0101000020E6100000000000000000F03F0000000000000040"
+      read (show hex) `shouldBe` hex -- placate the compiler (test keeps hex in scope)
+      let g = (fromString hex :: Geometry)
+      g `shouldBe` Geometry (Just 4326) (Point (Coord 1 2 Nothing Nothing))
+
+    it "round-trips a Point through hex EWKB" do
+      let g = Geometry Nothing (Point (Coord 3.5 (-1.25) Nothing Nothing))
+      read (show g) `shouldBe` g
+
+    it "round-trips an XYZM LineString through hex EWKB" do
+      let cs = [Coord 0 0 (Just 1) (Just 2), Coord 3 4 (Just 5) (Just 6)]
+          g = Geometry (Just 4326) (LineString cs)
+      read (show g) `shouldBe` g
+
+  describe "Property: full binary roundtrip for arbitrary geometries" do
+    it "holds for arbitrary shapes and SRIDs" $
+      property \(g :: Geometry) ->
+        read (show g) === g

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -64,8 +64,7 @@ spec = do
       -- byte-order NDR (01) + type 1 with SRID flag (01000020) + SRID 4326 (E6100000)
       --   + x=1.0 (000000000000F03F) + y=2.0 (0000000000000040)
       let hex = "0101000020E6100000000000000000F03F0000000000000040"
-      read (show hex) `shouldBe` hex -- placate the compiler (test keeps hex in scope)
-      let g = (fromString hex :: Geometry)
+          g = (fromString hex :: Geometry)
       g `shouldBe` Geometry (Just 4326) (Point (Coord 1 2 Nothing Nothing))
 
     it "round-trips a Point through hex EWKB" do

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -1,0 +1,46 @@
+module PostgresqlTypes.GeometrySpec (spec) where
+
+import qualified Data.ByteString as ByteString
+import Data.Data (Proxy (Proxy))
+import qualified PostgresqlTypes.Geometry as Geometry
+import Test.Hspec
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()
+import qualified UnitTests.Scripts as Scripts
+
+spec :: Spec
+spec = do
+  describe "Show/Read laws" do
+    Scripts.testShowRead (Proxy @Geometry.Geometry)
+
+  describe "IsScalar laws" do
+    Scripts.testIsScalar (Proxy @Geometry.Geometry)
+
+  describe "Constructors" do
+    describe "fromEWKB" do
+      it "wraps a ByteString of EWKB bytes" do
+        let bs = ByteString.pack [0x01, 0x01, 0x00, 0x00, 0x00]
+            geom = Geometry.fromEWKB bs
+        Geometry.toEWKB geom `shouldBe` bs
+
+      it "accepts the empty ByteString" do
+        Geometry.toEWKB (Geometry.fromEWKB ByteString.empty) `shouldBe` ByteString.empty
+
+      it "preserves binary data without mangling it" do
+        let bs = ByteString.pack [0, 255, 128, 1, 127]
+        Geometry.toEWKB (Geometry.fromEWKB bs) `shouldBe` bs
+
+  describe "Accessors" do
+    describe "toEWKB" do
+      it "extracts the underlying ByteString" do
+        let bs = ByteString.pack [10, 20, 30]
+        Geometry.toEWKB (Geometry.fromEWKB bs) `shouldBe` bs
+
+  describe "Property Tests" do
+    it "roundtrips through toEWKB and fromEWKB" do
+      property \(bs :: ByteString.ByteString) ->
+        Geometry.toEWKB (Geometry.fromEWKB bs) === bs
+
+    it "roundtrips through fromEWKB and toEWKB" do
+      property \(geom :: Geometry.Geometry) ->
+        Geometry.fromEWKB (Geometry.toEWKB geom) === geom


### PR DESCRIPTION
Models the PostGIS \`geometry\` extension type as a first-class member of this package, matching the style of the existing geometric types (\`Point\`, \`Line\`, \`Polygon\`, …). Because the PostGIS \`geometry\` OID is assigned dynamically when \`CREATE EXTENSION postgis\` runs, \`baseOid\` and \`arrayOid\` are \`Nothing\` — driver adapters (e.g. \`hasql-postgresql-types\`) resolve the OID by \`typeName\` at query time.

## Shape

\`\`\`haskell
data Geometry = Geometry { geometrySrid :: !(Maybe Int32), geometryShape :: !Shape }
data Shape
  = Point              !Coord
  | LineString         ![Coord]
  | Polygon            ![[Coord]]
  | MultiPoint         ![Coord]
  | MultiLineString    ![[Coord]]
  | MultiPolygon       ![[[Coord]]]
  | GeometryCollection ![Shape]
data Coord = Coord { coordX, coordY :: Double, coordZ, coordM :: Maybe Double }
\`\`\`

## Wire format

The \`IsScalar\` instance speaks the canonical PostGIS serializations:

- **Binary**: EWKB (little-endian NDR output; both endiannesses accepted on input, with the byte-order marker strictly validated). Type-code header carries the Z / M / SRID flag bits; the SRID field is only emitted on the outer geometry — sub-geometries in \`Multi*\` / \`GeometryCollection\` inherit the outer SRID, matching \`geometry_send\`.
- **Textual**: upper-case hex over the same EWKB payload — the format \`geometry_out\` produces and \`geometry_in\` accepts.

## Invariants

\`Geometry\` values share a single dimensionality across every coord in the tree. Smart constructors \`fromShape\` / \`fromShapeWithSrid\` validate that invariant; the raw constructor stays exported so pattern matching remains direct. \`binaryEncoder\` errors loudly (rather than silently dropping Z/M) if called on a value the smart constructors would have rejected. \`Hashable\` is implemented over the EWKB byte sequence for a fast, bit-stable hash.

## Tests

- **Unit** (\`unit-tests/PostgresqlTypes/GeometrySpec.hs\`): the shared \`Show\`/\`Read\` and \`IsScalar\` laws (100 samples each), smart-constructor dimension validation, a canonical hex-EWKB fixture from \`ST_AsEWKB(ST_SetSRID(ST_MakePoint(1, 2), 4326))\`, and a full arbitrary round-trip property.
- **Integration** (\`integration-tests/Main.hs\`): new \`postgis/postgis:17-3.5\` container block runs the existing \`mappingSpec\` harness against \`Geometry\`, exercising the dynamic-OID resolution end-to-end. The \`postgis/postgis\` image's initdb already registers the extension in the default database, so no \`CREATE EXTENSION\` step is needed from the test code. The pool is sized at 10 connections for this block (vs the default 100) since only one type is tested there and that keeps the runner's concurrent-socket count inside its comfort zone alongside the existing 3 containers.

The QuickCheck \`Arbitrary\` generator produces OGC-valid shapes: \`LineString\` has at least 2 coords, polygon rings are closed with at least 4 coords. SRIDs are restricted to \`[1, 998_999]\` — PostGIS's user-assignable range — because PostGIS rewrites \`SRID = 0\` to "no SRID" and modulo-remaps values above \`SRID_USER_MAXIMUM\`, which would otherwise break byte-for-byte round-trip.

## Notes for reviewers

- \`Shape\` has constructor names that overlap with existing type names in the package (\`Point\`, \`Polygon\`). Users who import \`PostgresqlTypes\` and \`PostgresqlTypes.Geometry\` unqualified will see a clash; the pragmatic guidance is to import \`PostgresqlTypes.Geometry\` qualified when pattern-matching on shapes. Happy to rename the constructors (e.g. \`GeomPoint\` / \`GeomPolygon\`) if you'd prefer to avoid the clash entirely.
- Only \`geometry\` is covered here; \`box2d\` / \`box3d\` / \`geography\` are left for follow-up PRs.
- Motivated by downstream use in IHP ([digitallyinduced/ihp#2646](https://github.com/digitallyinduced/ihp/pull/2646)), where a user reported that \`geometry\` columns don't map to a Haskell type out of the box. The fork being consumed there tracks this branch.

Happy to adjust shape, naming, or scope — let me know what you'd like changed.