### PR TITLE
Geometry: add CircularString support (LWTYPE 8)

### DIFF
--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -48,7 +48,7 @@ data Geometry
   deriving stock (Eq, Ord)
   deriving (Show, Read, IsString) via (ViaIsScalar Geometry)
 
--- | One of the seven OGC shapes that a 'Geometry' can hold.
+-- | One of the eight OGC shapes that a 'Geometry' can hold.
 data Shape
   = -- | Single coordinate.
     PointShape Coord
@@ -57,6 +57,10 @@ data Shape
   | -- | One or more linear rings. The first is the exterior ring, the rest are interior rings (holes).
     -- Every ring is closed: its last coordinate repeats its first.
     PolygonShape [[Coord]]
+  | -- | Circular arc string: a sequence of circular arcs, each defined by three consecutive
+    -- coordinates (start, midpoint on the arc, end), where the end of one arc is the start of the
+    -- next. Requires an odd number of coordinates, at least three.
+    CircularStringShape [Coord]
   | -- | Collection of points.
     MultiPointShape [Coord]
   | -- | Collection of line strings.
@@ -120,6 +124,7 @@ instance Hashable Shape where
     MultiLineStringShape lineStrings -> salt `hashWithSalt` (4 :: Int) `hashWithSalt` lineStrings
     MultiPolygonShape polygons -> salt `hashWithSalt` (5 :: Int) `hashWithSalt` polygons
     GeometryCollectionShape shapes -> salt `hashWithSalt` (6 :: Int) `hashWithSalt` shapes
+    CircularStringShape coords -> salt `hashWithSalt` (7 :: Int) `hashWithSalt` coords
 
 instance Hashable Coord where
   hashWithSalt salt = \case
@@ -248,6 +253,7 @@ shapeDim shape = fromMaybe XyDim <$> goShape Nothing shape
     goShape acc = \case
       PointShape coord -> goCoord acc coord
       LineStringShape coords -> goCoords acc coords
+      CircularStringShape coords -> goCoords acc coords
       PolygonShape rings -> foldM goCoords acc rings
       MultiPointShape coords -> goCoords acc coords
       MultiLineStringShape lineStrings -> foldM goCoords acc lineStrings
@@ -279,7 +285,7 @@ data ByteOrder
     LittleEndianByteOrder
 
 -- | OGC type codes, as they appear in the low bits of the EWKB type header.
-pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode :: Word32
+pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, circularStringTypeCode :: Word32
 pointTypeCode = 1
 lineStringTypeCode = 2
 polygonTypeCode = 3
@@ -287,6 +293,7 @@ multiPointTypeCode = 4
 multiLineStringTypeCode = 5
 multiPolygonTypeCode = 6
 geometryCollectionTypeCode = 7
+circularStringTypeCode = 8
 
 -- | Flag bits of the EWKB type header.
 zFlag, mFlag, sridFlag :: Word32
@@ -317,6 +324,7 @@ shapeToTypeCode = \case
   MultiLineStringShape {} -> multiLineStringTypeCode
   MultiPolygonShape {} -> multiPolygonTypeCode
   GeometryCollectionShape {} -> geometryCollectionTypeCode
+  CircularStringShape {} -> circularStringTypeCode
 
 -- | Name of the shape in the OGC vocabulary. Used for reporting decoding errors.
 shapeName :: Shape -> Text
@@ -328,6 +336,7 @@ shapeName = \case
   MultiLineStringShape {} -> "MultiLineString"
   MultiPolygonShape {} -> "MultiPolygon"
   GeometryCollectionShape {} -> "GeometryCollection"
+  CircularStringShape {} -> "CircularString"
 
 -- * Binary encoder
 
@@ -348,6 +357,7 @@ writeShape :: Dim -> Shape -> Write.Write
 writeShape dim = \case
   PointShape coord -> writeCoord coord
   LineStringShape coords -> writeCoords coords
+  CircularStringShape coords -> writeCoords coords
   PolygonShape rings -> writeCount rings <> foldMap writeCoords rings
   MultiPointShape coords -> writeCount coords <> foldMap (writeSubGeometry . PointShape) coords
   MultiLineStringShape lineStrings -> writeCount lineStrings <> foldMap (writeSubGeometry . LineStringShape) lineStrings
@@ -412,6 +422,8 @@ readShape byteOrder dim typeCode
       PointShape <$> lift (readCoord byteOrder dim)
   | typeCode == lineStringTypeCode =
       LineStringShape <$> lift readCoords
+  | typeCode == circularStringTypeCode =
+      CircularStringShape <$> lift readCoords
   | typeCode == polygonTypeCode =
       PolygonShape <$> lift (readSequence readCoords)
   | typeCode == multiPointTypeCode =
@@ -506,6 +518,7 @@ shapeGen dim size =
     simple =
       [ PointShape <$> coordGen dim,
         LineStringShape <$> lineStringCoordsGen dim,
+        CircularStringShape <$> circularStringCoordsGen dim,
         PolygonShape . pure <$> ringCoordsGen dim,
         MultiPointShape <$> QuickCheck.listOf (coordGen dim)
       ]
@@ -521,6 +534,14 @@ lineStringCoordsGen :: Dim -> QuickCheck.Gen [Coord]
 lineStringCoordsGen dim = do
   extra <- QuickCheck.choose (0, 6 :: Int)
   QuickCheck.vectorOf (2 + extra) (coordGen dim)
+
+-- | Generate the coordinates of a circular string. PostGIS's @geometry_recv@ enforces
+-- @LW_PARSER_CHECK_MINPOINTS | LW_PARSER_CHECK_ODD@ for circular strings: an odd number of
+-- coordinates, at least three, each consecutive triple describing one circular arc.
+circularStringCoordsGen :: Dim -> QuickCheck.Gen [Coord]
+circularStringCoordsGen dim = do
+  extraArcs <- QuickCheck.choose (0, 3 :: Int)
+  QuickCheck.vectorOf (3 + 2 * extraArcs) (coordGen dim)
 
 -- | Generate the coordinates of a linear ring, which OGC requires to be closed and to consist of at
 -- least four coordinates: three distinct ones plus the repetition of the first that closes it.
@@ -547,6 +568,8 @@ shrinkShape = \case
   PointShape _ -> []
   LineStringShape coords ->
     LineStringShape <$> filter ((>= 2) . length) (shrinkMembers coords)
+  CircularStringShape coords ->
+    CircularStringShape <$> filter (\cs -> length cs >= 3 && odd (length cs)) (shrinkMembers coords)
   PolygonShape rings ->
     PolygonShape <$> filter (not . null) (shrinkMembers rings)
   MultiPointShape coords ->

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -112,6 +112,24 @@ spec = do
     it "rejects a truncated payload" do
       decodeHex "0101000000000000000000F03F" `shouldSatisfy` isLeft
 
+    -- Fixture derived by hand from the EWKB layout (no live PostGIS instance required for this test):
+    -- a CircularString of one arc through (0,0), (1,2), (2,0), with SRID 4326.
+    --
+    -- Byte-order marker NDR (01), type 8 (CircularString) with the SRID flag (08000020), SRID 4326
+    -- (E6100000), coordinate count 3 (03000000), then the three coordinates: (0,0), (1,2), (2,0),
+    -- each ordinate as a little-endian IEEE-754 double.
+    let circularStringHex = "0108000020E61000000300000000000000000000000000000000000000000000000000F03F000000000000004000000000000000400000000000000000"
+        circularString =
+          Geometry.refineFromShapeAndSrid
+            (CircularStringShape [XyCoord 0 0, XyCoord 1 2, XyCoord 2 0])
+            (Just 4326)
+
+    it "decodes a circular string" do
+      fmap Just (decodeHex circularStringHex) `shouldBe` Right circularString
+
+    it "encodes a circular string the way PostGIS does" do
+      fmap encodeHex circularString `shouldBe` Just (Text.toLower circularStringHex)
+
     it "rejects a multi-point whose member is a line string" do
       decodeHex
         ( mconcat


### PR DESCRIPTION
## Summary
- Adds `CircularStringShape [Coord]` to `Shape`, mirroring `LineStringShape`'s wire layout but dispatching on WKB type code 8.
- `Arbitrary`/`shrink` generate an odd point count ≥ 3, per PostGIS's `LW_PARSER_CHECK_MINPOINTS | LW_PARSER_CHECK_ODD`.
- Hand-built WKB fixture in `GeometrySpec.hs` covering decode/encode.

## Test plan
- [x] `cabal build`
- [x] `cabal test unit-tests --test-options='--match Geometry'`
- [x] `cabal test integration-tests --test-options='--match "imresamu/postgis:17-3.5"'` — round-trips generated `CircularStringShape` values against a real PostGIS 17-3.5 server

Closes #72