### PR TITLE
Geometry: add Triangle support (LWTYPE 14, wire code 17)

### DIFF
--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -48,7 +48,7 @@ data Geometry
   deriving stock (Eq, Ord)
   deriving (Show, Read, IsString) via (ViaIsScalar Geometry)
 
--- | One of the seven OGC shapes that a 'Geometry' can hold.
+-- | One of the OGC shapes that a 'Geometry' can hold.
 data Shape
   = -- | Single coordinate.
     PointShape Coord
@@ -67,6 +67,10 @@ data Shape
     --
     -- Members do not carry their own SRID: they inherit the one of the enclosing 'Geometry'.
     GeometryCollectionShape [Shape]
+  | -- | A single linear ring, or none. Unlike 'PolygonShape', a triangle admits at most one ring: no
+    -- holes, and no more than one exterior boundary. The empty list represents a triangle with no ring
+    -- at all; a non-empty one is closed, its last coordinate repeating its first.
+    TriangleShape [Coord]
   deriving stock (Eq, Ord, Show, Read)
 
 -- | Coordinate in one of the four dimensionalities PostGIS supports.
@@ -120,6 +124,7 @@ instance Hashable Shape where
     MultiLineStringShape lineStrings -> salt `hashWithSalt` (4 :: Int) `hashWithSalt` lineStrings
     MultiPolygonShape polygons -> salt `hashWithSalt` (5 :: Int) `hashWithSalt` polygons
     GeometryCollectionShape shapes -> salt `hashWithSalt` (6 :: Int) `hashWithSalt` shapes
+    TriangleShape coords -> salt `hashWithSalt` (8 :: Int) `hashWithSalt` coords
 
 instance Hashable Coord where
   hashWithSalt salt = \case
@@ -253,6 +258,7 @@ shapeDim shape = fromMaybe XyDim <$> goShape Nothing shape
       MultiLineStringShape lineStrings -> foldM goCoords acc lineStrings
       MultiPolygonShape polygons -> foldM (foldM goCoords) acc polygons
       GeometryCollectionShape shapes -> foldM goShape acc shapes
+      TriangleShape coords -> goCoords acc coords
     goCoords :: Maybe Dim -> [Coord] -> Maybe (Maybe Dim)
     goCoords = foldM goCoord
     goCoord :: Maybe Dim -> Coord -> Maybe (Maybe Dim)
@@ -279,7 +285,7 @@ data ByteOrder
     LittleEndianByteOrder
 
 -- | OGC type codes, as they appear in the low bits of the EWKB type header.
-pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode :: Word32
+pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, triangleTypeCode :: Word32
 pointTypeCode = 1
 lineStringTypeCode = 2
 polygonTypeCode = 3
@@ -287,6 +293,7 @@ multiPointTypeCode = 4
 multiLineStringTypeCode = 5
 multiPolygonTypeCode = 6
 geometryCollectionTypeCode = 7
+triangleTypeCode = 17
 
 -- | Flag bits of the EWKB type header.
 zFlag, mFlag, sridFlag :: Word32
@@ -317,6 +324,7 @@ shapeToTypeCode = \case
   MultiLineStringShape {} -> multiLineStringTypeCode
   MultiPolygonShape {} -> multiPolygonTypeCode
   GeometryCollectionShape {} -> geometryCollectionTypeCode
+  TriangleShape {} -> triangleTypeCode
 
 -- | Name of the shape in the OGC vocabulary. Used for reporting decoding errors.
 shapeName :: Shape -> Text
@@ -328,6 +336,7 @@ shapeName = \case
   MultiLineStringShape {} -> "MultiLineString"
   MultiPolygonShape {} -> "MultiPolygon"
   GeometryCollectionShape {} -> "GeometryCollection"
+  TriangleShape {} -> "Triangle"
 
 -- * Binary encoder
 
@@ -353,6 +362,9 @@ writeShape dim = \case
   MultiLineStringShape lineStrings -> writeCount lineStrings <> foldMap (writeSubGeometry . LineStringShape) lineStrings
   MultiPolygonShape polygons -> writeCount polygons <> foldMap (writeSubGeometry . PolygonShape) polygons
   GeometryCollectionShape shapes -> writeCount shapes <> foldMap writeSubGeometry shapes
+  TriangleShape coords -> case coords of
+    [] -> Write.lWord32 0
+    _ -> Write.lWord32 1 <> writeCoords coords
   where
     writeCount :: [a] -> Write.Write
     writeCount = Write.lWord32 . fromIntegral . length
@@ -429,6 +441,17 @@ readShape byteOrder dim typeCode
   | typeCode == geometryCollectionTypeCode = do
       count <- lift (readWord32 byteOrder)
       GeometryCollectionShape <$> replicateM (fromIntegral count) (snd <$> readGeometry)
+  | typeCode == triangleTypeCode = do
+      ringCount <- lift (readWord32 byteOrder)
+      case ringCount of
+        0 -> pure (TriangleShape [])
+        1 -> TriangleShape <$> lift readCoords
+        _ ->
+          throwError
+            ( DecodingError
+                ["Triangle"]
+                (UnexpectedValueDecodingErrorReason "0 or 1 rings" (TextBuilder.toText (TextBuilder.decimal ringCount)))
+            )
   | otherwise =
       throwError
         ( DecodingError
@@ -507,7 +530,8 @@ shapeGen dim size =
       [ PointShape <$> coordGen dim,
         LineStringShape <$> lineStringCoordsGen dim,
         PolygonShape . pure <$> ringCoordsGen dim,
-        MultiPointShape <$> QuickCheck.listOf (coordGen dim)
+        MultiPointShape <$> QuickCheck.listOf (coordGen dim),
+        QuickCheck.oneof [pure (TriangleShape []), TriangleShape <$> ringCoordsGen dim]
       ]
     compound =
       [ MultiLineStringShape <$> QuickCheck.listOf (lineStringCoordsGen dim),
@@ -557,6 +581,8 @@ shrinkShape = \case
     MultiPolygonShape <$> shrinkMembers polygons
   GeometryCollectionShape shapes ->
     GeometryCollectionShape <$> QuickCheck.shrinkList shrinkShape shapes
+  TriangleShape coords ->
+    [TriangleShape [] | not (null coords)]
   where
     shrinkMembers :: [a] -> [[a]]
     shrinkMembers = QuickCheck.shrinkList (const [])

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -143,6 +143,53 @@ spec = do
         )
         `shouldSatisfy` isLeft
 
+    -- A triangle is a polygon restricted to 0 or 1 rings: a ring-count word32, followed by that one
+    -- ring's coordinates when present.
+    let emptyTriangleHex =
+          mconcat
+            [ "01", -- NDR
+              "11000000", -- type 17 (Triangle), no flags
+              "00000000" -- 0 rings
+            ]
+        emptyTriangle = Geometry.refineFromShape (TriangleShape [])
+
+    it "decodes an empty triangle" do
+      fmap Just (decodeHex emptyTriangleHex) `shouldBe` Right emptyTriangle
+
+    it "encodes an empty triangle" do
+      fmap encodeHex emptyTriangle `shouldBe` Just (Text.toLower emptyTriangleHex)
+
+    let nonEmptyTriangleHex =
+          mconcat
+            [ "01", -- NDR
+              "11000000", -- type 17 (Triangle), no flags
+              "01000000", -- 1 ring
+              "04000000", -- 4 coordinates
+              "00000000000000000000000000000000", -- (0, 0)
+              "00000000000010400000000000000000", -- (4, 0)
+              "00000000000000000000000000000840", -- (0, 3)
+              "00000000000000000000000000000000" -- (0, 0), closing the ring
+            ]
+        nonEmptyTriangle =
+          Geometry.refineFromShape
+            (TriangleShape [XyCoord 0 0, XyCoord 4 0, XyCoord 0 3, XyCoord 0 0])
+
+    it "decodes a non-empty triangle" do
+      fmap Just (decodeHex nonEmptyTriangleHex) `shouldBe` Right nonEmptyTriangle
+
+    it "encodes a non-empty triangle" do
+      fmap encodeHex nonEmptyTriangle `shouldBe` Just (Text.toLower nonEmptyTriangleHex)
+
+    it "rejects a triangle with more than one ring" do
+      decodeHex
+        ( mconcat
+            [ "01", -- NDR
+              "11000000", -- Triangle
+              "02000000" -- 2 rings, which a Triangle disallows
+            ]
+        )
+        `shouldSatisfy` isLeft
+
   describe "Hashable" do
     it "agrees with Eq on negative zero" do
       -- Hashing the EWKB bytes would break this: the two coordinates are equal, yet their IEEE


### PR DESCRIPTION
## Summary
- Adds `TriangleShape [Coord]` to `Shape` — a polygon restricted to exactly 0 or 1 rings on the wire (type code 17).
- Decoding a ring count other than 0 or 1 fails with a `DecodingError` rather than crashing or misparsing.
- `Arbitrary`/`shrink` generate closed rings of ≥ 4 points, reusing the existing `ringCoordsGen`.
- Hand-built WKB fixtures for the empty case, non-empty case, and the "wrong number of rings" decode-error path.

## Test plan
- [x] `cabal build`
- [x] `cabal test unit-tests --test-options='--match Geometry'` (also ran the full unit-tests suite: 809 examples, 0 failures)
- [x] `cabal test integration-tests --test-options='--match "imresamu/postgis:17-3.5"'` — round-trips generated `TriangleShape` values against a real PostGIS 17-3.5 server

Closes #73