### PR TITLE
Geometry: add PolyhedralSurface support (LWTYPE 13, wire code 15)

### DIFF
--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -63,6 +63,8 @@ data Shape
     MultiLineStringShape [[Coord]]
   | -- | Collection of polygons, each given as its list of rings.
     MultiPolygonShape [[[Coord]]]
+  | -- | Collection of polygon faces forming a surface, each given as its list of rings.
+    PolyhedralSurfaceShape [[[Coord]]]
   | -- | Heterogeneous collection of shapes.
     --
     -- Members do not carry their own SRID: they inherit the one of the enclosing 'Geometry'.
@@ -120,6 +122,7 @@ instance Hashable Shape where
     MultiLineStringShape lineStrings -> salt `hashWithSalt` (4 :: Int) `hashWithSalt` lineStrings
     MultiPolygonShape polygons -> salt `hashWithSalt` (5 :: Int) `hashWithSalt` polygons
     GeometryCollectionShape shapes -> salt `hashWithSalt` (6 :: Int) `hashWithSalt` shapes
+    PolyhedralSurfaceShape polygons -> salt `hashWithSalt` (9 :: Int) `hashWithSalt` polygons
 
 instance Hashable Coord where
   hashWithSalt salt = \case
@@ -252,6 +255,7 @@ shapeDim shape = fromMaybe XyDim <$> goShape Nothing shape
       MultiPointShape coords -> goCoords acc coords
       MultiLineStringShape lineStrings -> foldM goCoords acc lineStrings
       MultiPolygonShape polygons -> foldM (foldM goCoords) acc polygons
+      PolyhedralSurfaceShape polygons -> foldM (foldM goCoords) acc polygons
       GeometryCollectionShape shapes -> foldM goShape acc shapes
     goCoords :: Maybe Dim -> [Coord] -> Maybe (Maybe Dim)
     goCoords = foldM goCoord
@@ -279,7 +283,7 @@ data ByteOrder
     LittleEndianByteOrder
 
 -- | OGC type codes, as they appear in the low bits of the EWKB type header.
-pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode :: Word32
+pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, polyhedralSurfaceTypeCode :: Word32
 pointTypeCode = 1
 lineStringTypeCode = 2
 polygonTypeCode = 3
@@ -287,6 +291,7 @@ multiPointTypeCode = 4
 multiLineStringTypeCode = 5
 multiPolygonTypeCode = 6
 geometryCollectionTypeCode = 7
+polyhedralSurfaceTypeCode = 15
 
 -- | Flag bits of the EWKB type header.
 zFlag, mFlag, sridFlag :: Word32
@@ -316,6 +321,7 @@ shapeToTypeCode = \case
   MultiPointShape {} -> multiPointTypeCode
   MultiLineStringShape {} -> multiLineStringTypeCode
   MultiPolygonShape {} -> multiPolygonTypeCode
+  PolyhedralSurfaceShape {} -> polyhedralSurfaceTypeCode
   GeometryCollectionShape {} -> geometryCollectionTypeCode
 
 -- | Name of the shape in the OGC vocabulary. Used for reporting decoding errors.
@@ -327,6 +333,7 @@ shapeName = \case
   MultiPointShape {} -> "MultiPoint"
   MultiLineStringShape {} -> "MultiLineString"
   MultiPolygonShape {} -> "MultiPolygon"
+  PolyhedralSurfaceShape {} -> "PolyhedralSurface"
   GeometryCollectionShape {} -> "GeometryCollection"
 
 -- * Binary encoder
@@ -352,6 +359,7 @@ writeShape dim = \case
   MultiPointShape coords -> writeCount coords <> foldMap (writeSubGeometry . PointShape) coords
   MultiLineStringShape lineStrings -> writeCount lineStrings <> foldMap (writeSubGeometry . LineStringShape) lineStrings
   MultiPolygonShape polygons -> writeCount polygons <> foldMap (writeSubGeometry . PolygonShape) polygons
+  PolyhedralSurfaceShape polygons -> writeCount polygons <> foldMap (writeSubGeometry . PolygonShape) polygons
   GeometryCollectionShape shapes -> writeCount shapes <> foldMap writeSubGeometry shapes
   where
     writeCount :: [a] -> Write.Write
@@ -424,6 +432,10 @@ readShape byteOrder dim typeCode
         _ -> Nothing
   | typeCode == multiPolygonTypeCode =
       MultiPolygonShape <$> readSubShapes "MultiPolygon" "Polygon" \case
+        PolygonShape rings -> Just rings
+        _ -> Nothing
+  | typeCode == polyhedralSurfaceTypeCode =
+      PolyhedralSurfaceShape <$> readSubShapes "PolyhedralSurface" "Polygon" \case
         PolygonShape rings -> Just rings
         _ -> Nothing
   | typeCode == geometryCollectionTypeCode = do
@@ -512,6 +524,7 @@ shapeGen dim size =
     compound =
       [ MultiLineStringShape <$> QuickCheck.listOf (lineStringCoordsGen dim),
         MultiPolygonShape <$> QuickCheck.listOf (QuickCheck.listOf1 (ringCoordsGen dim)),
+        PolyhedralSurfaceShape <$> QuickCheck.listOf (QuickCheck.listOf1 (ringCoordsGen dim)),
         GeometryCollectionShape <$> QuickCheck.resize subSize (QuickCheck.listOf (shapeGen dim subSize))
       ]
     subSize = div size 4
@@ -555,6 +568,8 @@ shrinkShape = \case
     MultiLineStringShape <$> shrinkMembers lineStrings
   MultiPolygonShape polygons ->
     MultiPolygonShape <$> shrinkMembers polygons
+  PolyhedralSurfaceShape polygons ->
+    PolyhedralSurfaceShape <$> shrinkMembers polygons
   GeometryCollectionShape shapes ->
     GeometryCollectionShape <$> QuickCheck.shrinkList shrinkShape shapes
   where

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -112,6 +112,41 @@ spec = do
     it "rejects a truncated payload" do
       decodeHex "0101000000000000000000F03F" `shouldSatisfy` isLeft
 
+    -- Fixture produced by PostGIS itself:
+    -- SELECT ST_AsEWKB(ST_SetSRID(ST_GeomFromText(
+    --   'POLYHEDRALSURFACE(((0 0, 1 0, 0 1, 0 0)), ((0 0, 0 1, -1 0, 0 0)))'
+    -- ), 4326));
+    let polyhedralSurfaceHex = "010F000020E6100000020000000103000000010000000400000000000000000000000000000000000000000000000000F03F00000000000000000000000000000000000000000000F03F0000000000000000000000000000000001030000000100000004000000000000000000000000000000000000000000000000000000000000000000F03F000000000000F0BF000000000000000000000000000000000000000000000000"
+        polyhedralSurface =
+          Geometry.refineFromShapeAndSrid
+            ( PolyhedralSurfaceShape
+                [ [[XyCoord 0 0, XyCoord 1 0, XyCoord 0 1, XyCoord 0 0]],
+                  [[XyCoord 0 0, XyCoord 0 1, XyCoord (-1) 0, XyCoord 0 0]]
+                ]
+            )
+            (Just 4326)
+
+    it "decodes a polyhedral surface PostGIS produced" do
+      fmap Just (decodeHex polyhedralSurfaceHex) `shouldBe` Right polyhedralSurface
+
+    it "encodes a polyhedral surface the way PostGIS does" do
+      fmap encodeHex polyhedralSurface `shouldBe` Just (Text.toLower polyhedralSurfaceHex)
+
+    it "rejects a polyhedral surface whose member is a line string" do
+      decodeHex
+        ( mconcat
+            [ "01", -- NDR
+              "0F000000", -- PolyhedralSurface
+              "01000000", -- 1 member
+              "01", -- NDR
+              "02000000", -- LineString, where a Polygon is required
+              "02000000", -- 2 coordinates
+              "000000000000F03F0000000000000040",
+              "00000000000008400000000000001040"
+            ]
+        )
+        `shouldSatisfy` isLeft
+
     it "rejects a multi-point whose member is a line string" do
       decodeHex
         ( mconcat


### PR DESCRIPTION
## Summary
- Adds `PolyhedralSurfaceShape [[[Coord]]]` to `Shape` — a homogeneous collection of polygon faces, structurally identical to `MultiPolygonShape`'s wire format but under type code 15, with each member required to be a `Polygon` (via `readSubShapes`).
- `Arbitrary`/`shrink` reuse `ringCoordsGen`, whose ring-closing repetition already satisfies PostGIS's stricter Z-closure check for polyhedral surface faces.
- WKB fixture captured live from a real PostGIS 17-3.5 instance, plus a decode-error test for a non-polygon member.

## Test plan
- [x] `cabal build`
- [x] `cabal test unit-tests --test-options='--match Geometry'`
- [x] `cabal test integration-tests --test-options='--match "imresamu/postgis:17-3.5"'` — round-trips generated `PolyhedralSurfaceShape` values against a real PostGIS 17-3.5 server

Closes #74