### PR TITLE
Geometry: add NURBS curve support (LWTYPE 16, wire code 21)

### DIFF
--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -2,6 +2,7 @@ module PostgresqlTypes.Geometry
   ( Geometry,
     Shape (..),
     Coord (..),
+    NurbsCurve (..),
 
     -- * Accessors
     toSrid,
@@ -38,6 +39,12 @@ import qualified TextBuilder
 -- Unlike the built-in PostgreSQL types, @geometry@ is registered by @CREATE EXTENSION postgis@ and receives a different OID in every database.
 -- 'baseOid' and 'arrayOid' are therefore 'Nothing', and drivers are expected to resolve the OID by 'typeName' at runtime.
 --
+-- __NURBS curves__ ('NurbsCurveShape') are the one shape not validated against a real PostGIS server: support for
+-- them only landed in PostGIS's development branch in June 2026, no released PostGIS version speaks the wire
+-- format yet, and that format has seen several revisions and may still change upstream. This codec is derived
+-- from the ISO/IEC 13249-3:2016 spec and hand-built fixtures alone. Accordingly, 'NurbsCurveShape' is deliberately
+-- excluded from the 'Arbitrary'\/'shrink' instances below and from the real-server integration test suite.
+--
 -- [PostGIS docs](https://postgis.net/docs/geometry.html).
 data Geometry
   = Geometry
@@ -67,6 +74,10 @@ data Shape
     --
     -- Members do not carry their own SRID: they inherit the one of the enclosing 'Geometry'.
     GeometryCollectionShape [Shape]
+  | -- | Non-Uniform Rational B-Spline curve (ISO/IEC 13249-3:2016).
+    --
+    -- __Caution:__ untested against any real PostGIS server. See the note on 'Geometry'.
+    NurbsCurveShape NurbsCurve
   deriving stock (Eq, Ord, Show, Read)
 
 -- | Coordinate in one of the four dimensionalities PostGIS supports.
@@ -107,6 +118,19 @@ data Coord
       Double
   deriving stock (Eq, Ord, Show, Read)
 
+-- | Non-Uniform Rational B-Spline curve, per ISO/IEC 13249-3:2016 (SQL/MM Spatial).
+--
+-- __Caution:__ untested against any real PostGIS server. See the note on 'Geometry'.
+data NurbsCurve
+  = NurbsCurve
+      -- | Degree.
+      Word32
+      -- | Control points, each paired with its weight. A weight of @1@ is unweighted.
+      [(Coord, Double)]
+      -- | Knot vector.
+      [Double]
+  deriving stock (Eq, Ord, Show, Read)
+
 instance Hashable Geometry where
   hashWithSalt salt (Geometry srid shape) =
     salt `hashWithSalt` srid `hashWithSalt` shape
@@ -120,6 +144,9 @@ instance Hashable Shape where
     MultiLineStringShape lineStrings -> salt `hashWithSalt` (4 :: Int) `hashWithSalt` lineStrings
     MultiPolygonShape polygons -> salt `hashWithSalt` (5 :: Int) `hashWithSalt` polygons
     GeometryCollectionShape shapes -> salt `hashWithSalt` (6 :: Int) `hashWithSalt` shapes
+    -- Tag index 10: 0-6 are the constructors above; 7, 8 and 9 are reserved for shapes added by
+    -- parallel tickets (#72-#78) landing in separate worktrees, to avoid collisions on merge.
+    NurbsCurveShape nurbsCurve -> salt `hashWithSalt` (10 :: Int) `hashWithSalt` nurbsCurve
 
 instance Hashable Coord where
   hashWithSalt salt = \case
@@ -127,6 +154,10 @@ instance Hashable Coord where
     XyzCoord x y z -> salt `hashWithSalt` (1 :: Int) `hashWithSalt` x `hashWithSalt` y `hashWithSalt` z
     XymCoord x y m -> salt `hashWithSalt` (2 :: Int) `hashWithSalt` x `hashWithSalt` y `hashWithSalt` m
     XyzmCoord x y z m -> salt `hashWithSalt` (3 :: Int) `hashWithSalt` x `hashWithSalt` y `hashWithSalt` z `hashWithSalt` m
+
+instance Hashable NurbsCurve where
+  hashWithSalt salt (NurbsCurve degree controlPoints knots) =
+    salt `hashWithSalt` degree `hashWithSalt` controlPoints `hashWithSalt` knots
 
 instance Arbitrary Geometry where
   arbitrary = do
@@ -253,6 +284,7 @@ shapeDim shape = fromMaybe XyDim <$> goShape Nothing shape
       MultiLineStringShape lineStrings -> foldM goCoords acc lineStrings
       MultiPolygonShape polygons -> foldM (foldM goCoords) acc polygons
       GeometryCollectionShape shapes -> foldM goShape acc shapes
+      NurbsCurveShape (NurbsCurve _ controlPoints _) -> goCoords acc (fst <$> controlPoints)
     goCoords :: Maybe Dim -> [Coord] -> Maybe (Maybe Dim)
     goCoords = foldM goCoord
     goCoord :: Maybe Dim -> Coord -> Maybe (Maybe Dim)
@@ -288,6 +320,42 @@ multiLineStringTypeCode = 5
 multiPolygonTypeCode = 6
 geometryCollectionTypeCode = 7
 
+-- | ISO/IEC 13249-3 (SQL/MM) type code for a NURBS curve.
+--
+-- Unlike the seven OGC shapes above, PostGIS's WKB writer signals a NURBS curve's dimensionality
+-- through this code's magnitude rather than through 'zFlag'\/'mFlag': the wire byte is
+-- @nurbsCurveBaseTypeCode + isoDimOffset dim@, e.g. @1021@ for an XYZ curve. See 'isoDimOffset'.
+nurbsCurveBaseTypeCode :: Word32
+nurbsCurveBaseTypeCode = 21
+
+-- | Dimensionality offset that PostGIS's WKB writer adds to 'nurbsCurveBaseTypeCode', per the
+-- ISO/IEC 13249-3 (SQL/MM) extended-WKB numbering scheme: plain 2D types occupy 1-999, @+1000@
+-- selects the Z variant, @+2000@ the M variant and @+3000@ the ZM variant.
+--
+-- __Assumption, not verified against a released PostGIS:__ NURBS curve support only exists on
+-- PostGIS's development branch (merged June 2026) and no released version speaks this format, so
+-- this can't be checked against real server output. The @+1000@\/@+2000@\/@+3000@ offsets are given
+-- directly by the ticket that specified this feature, and the "no offset means 2D" reading follows
+-- the same SQL/MM scheme PostGIS already uses for its other ISO curve\/surface type codes (e.g.
+-- @CircularString@ = 8, @CompoundCurve@ = 9, none of which this codebase implements) — those, too,
+-- carry no offset for their bare 2D form. If PostGIS's actual NURBS implementation turns out to
+-- reserve 0 for something other than XY, only this function and 'isoOffsetToDim' need to change.
+isoDimOffset :: Dim -> Word32
+isoDimOffset = \case
+  XyDim -> 0
+  XyzDim -> 1000
+  XymDim -> 2000
+  XyzmDim -> 3000
+
+-- | Inverse of 'isoDimOffset'. 'Nothing' for any offset PostGIS's NURBS writer is not documented to emit.
+isoOffsetToDim :: Word32 -> Maybe Dim
+isoOffsetToDim = \case
+  0 -> Just XyDim
+  1 -> Just XyzDim
+  2 -> Just XymDim
+  3 -> Just XyzmDim
+  _ -> Nothing
+
 -- | Flag bits of the EWKB type header.
 zFlag, mFlag, sridFlag :: Word32
 zFlag = 0x80000000
@@ -317,6 +385,7 @@ shapeToTypeCode = \case
   MultiLineStringShape {} -> multiLineStringTypeCode
   MultiPolygonShape {} -> multiPolygonTypeCode
   GeometryCollectionShape {} -> geometryCollectionTypeCode
+  NurbsCurveShape {} -> nurbsCurveBaseTypeCode
 
 -- | Name of the shape in the OGC vocabulary. Used for reporting decoding errors.
 shapeName :: Shape -> Text
@@ -328,6 +397,7 @@ shapeName = \case
   MultiLineStringShape {} -> "MultiLineString"
   MultiPolygonShape {} -> "MultiPolygon"
   GeometryCollectionShape {} -> "GeometryCollection"
+  NurbsCurveShape {} -> "NurbsCurve"
 
 -- * Binary encoder
 
@@ -339,10 +409,17 @@ writeGeometry :: Maybe Int32 -> Dim -> Shape -> Write.Write
 writeGeometry srid dim shape =
   mconcat
     [ Write.word8 1,
-      Write.lWord32 (shapeToTypeCode shape .|. dimToFlags dim .|. maybe 0 (const sridFlag) srid),
+      Write.lWord32 (typeCode .|. maybe 0 (const sridFlag) srid),
       foldMap (Write.lWord32 . fromIntegral) srid,
       writeShape dim shape
     ]
+  where
+    -- A NURBS curve is the one shape whose dimensionality PostGIS's writer bakes into the type
+    -- code's magnitude (see 'isoDimOffset') instead of the Z\/M flag bits every other shape uses.
+    -- The SRID flag above is unaffected either way: it is a separate bit that both schemes share.
+    typeCode = case shape of
+      NurbsCurveShape {} -> shapeToTypeCode shape + isoDimOffset dim
+      _ -> shapeToTypeCode shape .|. dimToFlags dim
 
 writeShape :: Dim -> Shape -> Write.Write
 writeShape dim = \case
@@ -353,6 +430,7 @@ writeShape dim = \case
   MultiLineStringShape lineStrings -> writeCount lineStrings <> foldMap (writeSubGeometry . LineStringShape) lineStrings
   MultiPolygonShape polygons -> writeCount polygons <> foldMap (writeSubGeometry . PolygonShape) polygons
   GeometryCollectionShape shapes -> writeCount shapes <> foldMap writeSubGeometry shapes
+  NurbsCurveShape nurbsCurve -> writeNurbsCurve nurbsCurve
   where
     writeCount :: [a] -> Write.Write
     writeCount = Write.lWord32 . fromIntegral . length
@@ -374,6 +452,34 @@ writeCoord = \case
   where
     writeDouble = Write.lWord64 . castDoubleToWord64
 
+-- | Encode a NURBS curve's body: degree, then the count-prefixed control points, then the
+-- count-prefixed knot vector. Mirrors 'readNurbsCurve'.
+writeNurbsCurve :: NurbsCurve -> Write.Write
+writeNurbsCurve (NurbsCurve degree controlPoints knots) =
+  mconcat
+    [ Write.lWord32 degree,
+      Write.lWord32 (fromIntegral (length controlPoints)),
+      foldMap writeNurbsControlPoint controlPoints,
+      Write.lWord32 (fromIntegral (length knots)),
+      foldMap writeDouble knots
+    ]
+  where
+    writeDouble = Write.lWord64 . castDoubleToWord64
+
+-- | Encode one control point: its own (redundant, but ISO-mandated) byte-order marker — always NDR,
+-- matching the rest of this encoder — then its coordinates, then the weight flag byte. A weight of
+-- exactly @1.0@ is the default and is written as flag @0@ with the weight omitted; any other value,
+-- including @0.0@, is written explicitly as flag @1@ followed by the weight.
+writeNurbsControlPoint :: (Coord, Double) -> Write.Write
+writeNurbsControlPoint (coord, weight) =
+  mconcat
+    [ Write.word8 1,
+      writeCoord coord,
+      if weight == 1.0
+        then Write.word8 0
+        else Write.word8 1 <> Write.lWord64 (castDoubleToWord64 weight)
+    ]
+
 -- * Binary decoder
 
 -- | Decode an EWKB geometry, yielding its SRID and shape.
@@ -394,16 +500,38 @@ readGeometry = do
             (UnexpectedValueDecodingErrorReason "0 or 1" (TextBuilder.toText (TextBuilder.decimal byteOrderMarker)))
         )
   typeWithFlags <- lift (readWord32 byteOrder)
-  let dim = case (testBit typeWithFlags 31, testBit typeWithFlags 30) of
-        (False, False) -> XyDim
-        (True, False) -> XyzDim
-        (False, True) -> XymDim
-        (True, True) -> XyzmDim
+  let maskedTypeCode = typeWithFlags .&. typeCodeMask
+  -- A NURBS curve is the one shape whose dimensionality is not carried in the Z/M flag bits
+  -- (testBit 31 / testBit 30): PostGIS's writer instead bakes it into the type code's magnitude
+  -- (see 'isoDimOffset'). Detect that case first, from the masked type code alone, before falling
+  -- back to the ordinary flag-bit interpretation every other shape uses.
+  (dim, typeCode) <-
+    if maskedTypeCode `mod` 1000 == nurbsCurveBaseTypeCode
+      then case isoOffsetToDim (maskedTypeCode `div` 1000) of
+        Just isoDim -> pure (isoDim, nurbsCurveBaseTypeCode)
+        Nothing ->
+          throwError
+            ( DecodingError
+                ["type-code"]
+                ( UnsupportedValueDecodingErrorReason
+                    "Unknown NURBS curve ISO dimensionality offset"
+                    (TextBuilder.toText (TextBuilder.decimal maskedTypeCode))
+                )
+            )
+      else
+        pure
+          ( case (testBit typeWithFlags 31, testBit typeWithFlags 30) of
+              (False, False) -> XyDim
+              (True, False) -> XyzDim
+              (False, True) -> XymDim
+              (True, True) -> XyzmDim,
+            maskedTypeCode
+          )
   srid <-
     if testBit typeWithFlags 29
       then Just . fromIntegral <$> lift (readWord32 byteOrder)
       else pure Nothing
-  shape <- readShape byteOrder dim (typeWithFlags .&. typeCodeMask)
+  shape <- readShape byteOrder dim typeCode
   pure (srid, shape)
 
 readShape :: ByteOrder -> Dim -> Word32 -> ExceptT DecodingError PtrPeeker.Variable Shape
@@ -429,6 +557,8 @@ readShape byteOrder dim typeCode
   | typeCode == geometryCollectionTypeCode = do
       count <- lift (readWord32 byteOrder)
       GeometryCollectionShape <$> replicateM (fromIntegral count) (snd <$> readGeometry)
+  | typeCode == nurbsCurveBaseTypeCode =
+      NurbsCurveShape <$> readNurbsCurve byteOrder dim
   | otherwise =
       throwError
         ( DecodingError
@@ -473,6 +603,45 @@ readCoord byteOrder = \case
   where
     readDouble = castWord64ToDouble <$> readWord64 byteOrder
 
+-- | Decode a NURBS curve's body: degree, then the count-prefixed control points, then the
+-- count-prefixed knot vector. Mirrors 'writeNurbsCurve'.
+--
+-- No arithmetic relationship between the degree, control point count and knot count is checked:
+-- as elsewhere in this codebase, already-server-validated structure is trusted rather than
+-- re-validated.
+readNurbsCurve :: ByteOrder -> Dim -> ExceptT DecodingError PtrPeeker.Variable NurbsCurve
+readNurbsCurve byteOrder dim = do
+  degree <- lift (readWord32 byteOrder)
+  pointCount <- lift (readWord32 byteOrder)
+  controlPoints <- replicateM (fromIntegral pointCount) (readNurbsControlPoint dim)
+  knotCount <- lift (readWord32 byteOrder)
+  knots <- lift (replicateM (fromIntegral knotCount) readDouble)
+  pure (NurbsCurve degree controlPoints knots)
+  where
+    readDouble = castWord64ToDouble <$> readWord64 byteOrder
+
+-- | Decode one control point: its own (redundant, but ISO-mandated) byte-order marker, then its
+-- coordinates in that byte order, then a weight flag byte — @0@ means the default weight @1.0@
+-- (omitted on the wire), @1@ means an explicit weight follows.
+readNurbsControlPoint :: Dim -> ExceptT DecodingError PtrPeeker.Variable (Coord, Double)
+readNurbsControlPoint dim = do
+  pointByteOrderMarker <- lift (PtrPeeker.fixed PtrPeeker.unsignedInt1)
+  pointByteOrder <- case pointByteOrderMarker of
+    0 -> pure BigEndianByteOrder
+    1 -> pure LittleEndianByteOrder
+    _ ->
+      throwError
+        ( DecodingError
+            ["nurbs-curve", "control-point", "byte-order-marker"]
+            (UnexpectedValueDecodingErrorReason "0 or 1" (TextBuilder.toText (TextBuilder.decimal pointByteOrderMarker)))
+        )
+  coord <- lift (readCoord pointByteOrder dim)
+  hasWeight <- lift (PtrPeeker.fixed PtrPeeker.unsignedInt1)
+  weight <- case hasWeight of
+    0 -> pure 1.0
+    _ -> lift (castWord64ToDouble <$> readWord64 pointByteOrder)
+  pure (coord, weight)
+
 readWord32 :: ByteOrder -> PtrPeeker.Variable Word32
 readWord32 = \case
   BigEndianByteOrder -> PtrPeeker.fixed PtrPeeker.beUnsignedInt4
@@ -499,6 +668,11 @@ shrinkSrid = filter (maybe True (\srid -> srid >= 1 && srid <= 998_999)) . shrin
 
 -- | Generate a shape whose every coordinate is of the given dimensionality and which satisfies the
 -- structural constraints OGC places on it, so that PostGIS accepts it.
+--
+-- __'NurbsCurveShape' is deliberately never generated here.__ NURBS curve support is not in any
+-- released PostGIS version (see the note on 'Geometry'), and the real-server integration test
+-- suite draws its 'Geometry' values from this generator; producing one here would break that suite
+-- against a server that cannot parse it. Do not add it without first revisiting that risk.
 shapeGen :: Dim -> Int -> QuickCheck.Gen Shape
 shapeGen dim size =
   QuickCheck.oneof (if size <= 1 then simple else simple <> compound)
@@ -557,6 +731,9 @@ shrinkShape = \case
     MultiPolygonShape <$> shrinkMembers polygons
   GeometryCollectionShape shapes ->
     GeometryCollectionShape <$> QuickCheck.shrinkList shrinkShape shapes
+  -- 'shapeGen' never produces this constructor (see the comment there), so this is never called
+  -- with one in practice. Covered only so the pattern match above stays exhaustive.
+  NurbsCurveShape _ -> []
   where
     shrinkMembers :: [a] -> [[a]]
     shrinkMembers = QuickCheck.shrinkList (const [])

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -8,7 +8,7 @@ import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified PostgresqlTypes.Algebra
-import PostgresqlTypes.Geometry (Coord (..), Geometry, Shape (..))
+import PostgresqlTypes.Geometry (Coord (..), Geometry, NurbsCurve (..), Shape (..))
 import qualified PostgresqlTypes.Geometry as Geometry
 import Test.Hspec
 import Test.QuickCheck
@@ -142,6 +142,126 @@ spec = do
             ]
         )
         `shouldSatisfy` isLeft
+
+    describe "NurbsCurve" do
+      -- These fixtures cannot be captured from a real server: NURBS curve support only exists on
+      -- PostGIS's development branch (merged June 2026), no released PostGIS version speaks this
+      -- format, and the format has seen several revisions. They are instead reasoned by hand from
+      -- the wire layout PostGIS's WKB reader/writer (@lwin_wkb.c@/@lwout_wkb.c@) is documented to
+      -- use for ISO/IEC 13249-3:2016 NURBS curves:
+      --
+      --   * Byte-order marker, then a type code whose *magnitude* (not the usual Z/M flag bits)
+      --     encodes dimensionality: base code 21, +1000/+2000/+3000 for XYZ/XYM/XYZM, no offset
+      --     for plain XY. The SRID flag bit is the ordinary EWKB one.
+      --   * @degree@ (Word32), then count-prefixed control points, each with its own redundant
+      --     byte-order marker, its coordinates, and a weight flag byte (0 = default weight 1.0
+      --     omitted, 1 = an explicit weight double follows).
+      --   * A count-prefixed knot vector of plain doubles.
+      --
+      -- Every multi-byte field below is little-endian (NDR), and doubles use the same IEEE 754 hex
+      -- encoding as the 'pointHex' fixture above (e.g. 1.0 = 000000000000F03F, 2.0 =
+      -- 0000000000000040, verified the same way: byte-swap the well-known big-endian bit pattern).
+
+      it "decodes and re-encodes a 2D curve with default weights" do
+        -- A quadratic (degree 2) curve through (0,0), (1,1), (2,0), clamped knot vector
+        -- [0,0,0,1,1,1], no SRID, every control point at the default weight (flag byte 0).
+        let hex =
+              mconcat
+                [ "01", -- NDR
+                  "15000000", -- type code: base 21 + ISO offset 0 (XY), no SRID flag
+                  "02000000", -- degree = 2
+                  "03000000", -- 3 control points
+                  "01", -- control point 1: its own NDR marker
+                  "0000000000000000", -- x = 0.0
+                  "0000000000000000", -- y = 0.0
+                  "00", -- default weight (1.0, omitted)
+                  "01", -- control point 2: its own NDR marker
+                  "000000000000F03F", -- x = 1.0
+                  "000000000000F03F", -- y = 1.0
+                  "00", -- default weight
+                  "01", -- control point 3: its own NDR marker
+                  "0000000000000040", -- x = 2.0
+                  "0000000000000000", -- y = 0.0
+                  "00", -- default weight
+                  "06000000", -- 6 knots
+                  "0000000000000000", -- 0.0
+                  "0000000000000000", -- 0.0
+                  "0000000000000000", -- 0.0
+                  "000000000000F03F", -- 1.0
+                  "000000000000F03F", -- 1.0
+                  "000000000000F03F" -- 1.0
+                ]
+            shape =
+              NurbsCurveShape
+                ( NurbsCurve
+                    2
+                    [ (XyCoord 0 0, 1.0),
+                      (XyCoord 1 1, 1.0),
+                      (XyCoord 2 0, 1.0)
+                    ]
+                    [0, 0, 0, 1, 1, 1]
+                )
+            geometry = Geometry.refineFromShape shape
+
+        fmap Just (decodeHex hex) `shouldBe` Right geometry
+        fmap encodeHex geometry `shouldBe` Just (Text.toLower hex)
+
+      it "decodes and re-encodes a 3D curve with a mix of default and custom weights, under an SRID" do
+        -- A cubic (degree 3) curve with 2 control points: (0,0,0) with an explicit weight of 2.5,
+        -- and (1,1,1) at the default weight. SRID 4326, same as the 'pointHex' fixture.
+        let hex =
+              mconcat
+                [ "01", -- NDR
+                  "FD030020", -- type code: base 21 + ISO offset 1000 (XYZ) = 1021 (0x3FD), | SRID flag
+                  "E6100000", -- SRID 4326
+                  "03000000", -- degree = 3
+                  "02000000", -- 2 control points
+                  "01", -- control point 1: its own NDR marker
+                  "0000000000000000", -- x = 0.0
+                  "0000000000000000", -- y = 0.0
+                  "0000000000000000", -- z = 0.0
+                  "01", -- explicit weight follows
+                  "0000000000000440", -- weight = 2.5
+                  "01", -- control point 2: its own NDR marker
+                  "000000000000F03F", -- x = 1.0
+                  "000000000000F03F", -- y = 1.0
+                  "000000000000F03F", -- z = 1.0
+                  "00", -- default weight (1.0, omitted)
+                  "04000000", -- 4 knots
+                  "0000000000000000", -- 0.0
+                  "0000000000000000", -- 0.0
+                  "000000000000F03F", -- 1.0
+                  "000000000000F03F" -- 1.0
+                ]
+            shape =
+              NurbsCurveShape
+                ( NurbsCurve
+                    3
+                    [ (XyzCoord 0 0 0, 2.5),
+                      (XyzCoord 1 1 1, 1.0)
+                    ]
+                    [0, 0, 1, 1]
+                )
+            geometry = Geometry.refineFromShapeAndSrid shape (Just 4326)
+
+        fmap Just (decodeHex hex) `shouldBe` Right geometry
+        fmap encodeHex geometry `shouldBe` Just (Text.toLower hex)
+
+      it "decodes and re-encodes the empty curve" do
+        -- Degree 0, no control points, no knots. No SRID.
+        let hex =
+              mconcat
+                [ "01", -- NDR
+                  "15000000", -- type code: base 21 + ISO offset 0 (XY), no SRID flag
+                  "00000000", -- degree = 0
+                  "00000000", -- 0 control points
+                  "00000000" -- 0 knots
+                ]
+            shape = NurbsCurveShape (NurbsCurve 0 [] [])
+            geometry = Geometry.refineFromShape shape
+
+        fmap Just (decodeHex hex) `shouldBe` Right geometry
+        fmap encodeHex geometry `shouldBe` Just (Text.toLower hex)
 
   describe "Hashable" do
     it "agrees with Eq on negative zero" do


### PR DESCRIPTION
## Summary
- Adds a `NurbsCurve` type and `NurbsCurveShape NurbsCurve` constructor implementing ISO/IEC 13249-3:2016 NURBS curves.
- Handles the ISO-style type-code dimensionality offset (base 21, +1000/+2000/+3000 for XYZ/XYM/XYZM) that PostGIS's NURBS writer uses instead of the ordinary Z/M flag bits — `readGeometry`/`writeGeometry` are special-cased for this one shape while staying byte-for-byte unchanged for every other type.
- Per-control-point byte-order marker, coordinates, and optional weight (default 1.0) are round-tripped; knot vector is a plain count-prefixed list of doubles.
- **Deliberately excluded from `Arbitrary`/`shrink` and the real-PostGIS integration suite**: NURBS curve support only exists on PostGIS's development branch (merged June 2026), no released version speaks this wire format yet, and it may still change upstream. Covered by hand-built unit fixtures only (2D default-weight curve, 3D mixed-weight curve under an SRID, and the empty curve), reasoned from the ISO/IEC 13249-3:2016 spec since there's no real server to capture fixtures from.
- `Geometry`'s Haddock notes this caveat.

## Test plan
- [x] `cabal build`
- [x] `cabal test unit-tests --test-options='--match Geometry'` (re-ran with `--qc-max-success=2000` to confirm `Arbitrary`/`shrink` never produce `NurbsCurveShape`)
- [x] `cabal test integration-tests --test-options='--match "imresamu/postgis:17-3.5"'` — confirms no regression to any other shape kind's encode/decode dispatch (NURBS itself is intentionally not exercised here)
- [x] `ormolu --mode check`

Closes #79