### PR TITLE
Geometry: add CompoundCurve support (LWTYPE 9)

### DIFF
--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -3,6 +3,7 @@ module PostgresqlTypes.Geometry
     Shape (..),
     Coord (..),
     NurbsCurve (..),
+    CurveSegment (..),
 
     -- * Accessors
     toSrid,
@@ -88,6 +89,15 @@ data Shape
     --
     -- __Caution:__ untested against any real PostGIS server. See the note on 'Geometry'.
     NurbsCurveShape NurbsCurve
+  | -- | Curve assembled by chaining line and arc segments end to end.
+    --
+    -- Members are restricted to 'CurveSegment' rather than 'Shape': unlike
+    -- 'GeometryCollectionShape', which legitimately allows arbitrary nesting per OGC, a compound
+    -- curve's members can only be a @LineString@ or a @CircularString@, never another
+    -- @CompoundCurve@ or anything else. 'CurveSegment' makes that illegal nesting unrepresentable
+    -- at compile time, the same reasoning that already led 'MultiPointShape' to store raw
+    -- @['Coord']@ rather than @['Shape']@.
+    CompoundCurveShape [CurveSegment]
   deriving stock (Eq, Ord, Show, Read)
 
 -- | Coordinate in one of the four dimensionalities PostGIS supports.
@@ -141,6 +151,16 @@ data NurbsCurve
       [Double]
   deriving stock (Eq, Ord, Show, Read)
 
+-- | One continuous curve segment: the building block of a 'CompoundCurveShape'.
+--
+-- Deliberately does not reuse 'Shape' — see the Haddock on 'CompoundCurveShape' for why.
+data CurveSegment
+  = -- | Straight segment, wire-compatible with 'LineStringShape'.
+    LineSegment [Coord]
+  | -- | Circular-arc segment, wire-compatible with 'CircularStringShape'.
+    ArcSegment [Coord]
+  deriving stock (Eq, Ord, Show, Read)
+
 instance Hashable Geometry where
   hashWithSalt salt (Geometry srid shape) =
     salt `hashWithSalt` srid `hashWithSalt` shape
@@ -158,6 +178,7 @@ instance Hashable Shape where
     TriangleShape coords -> salt `hashWithSalt` (8 :: Int) `hashWithSalt` coords
     PolyhedralSurfaceShape polygons -> salt `hashWithSalt` (9 :: Int) `hashWithSalt` polygons
     NurbsCurveShape nurbsCurve -> salt `hashWithSalt` (10 :: Int) `hashWithSalt` nurbsCurve
+    CompoundCurveShape segments -> salt `hashWithSalt` (12 :: Int) `hashWithSalt` segments
 
 instance Hashable Coord where
   hashWithSalt salt = \case
@@ -169,6 +190,11 @@ instance Hashable Coord where
 instance Hashable NurbsCurve where
   hashWithSalt salt (NurbsCurve degree controlPoints knots) =
     salt `hashWithSalt` degree `hashWithSalt` controlPoints `hashWithSalt` knots
+
+instance Hashable CurveSegment where
+  hashWithSalt salt = \case
+    LineSegment coords -> salt `hashWithSalt` (0 :: Int) `hashWithSalt` coords
+    ArcSegment coords -> salt `hashWithSalt` (1 :: Int) `hashWithSalt` coords
 
 instance Arbitrary Geometry where
   arbitrary = do
@@ -299,6 +325,11 @@ shapeDim shape = fromMaybe XyDim <$> goShape Nothing shape
       GeometryCollectionShape shapes -> foldM goShape acc shapes
       TriangleShape coords -> goCoords acc coords
       NurbsCurveShape (NurbsCurve _ controlPoints _) -> goCoords acc (fst <$> controlPoints)
+      CompoundCurveShape segments -> foldM goSegment acc segments
+    goSegment :: Maybe Dim -> CurveSegment -> Maybe (Maybe Dim)
+    goSegment acc = \case
+      LineSegment coords -> goCoords acc coords
+      ArcSegment coords -> goCoords acc coords
     goCoords :: Maybe Dim -> [Coord] -> Maybe (Maybe Dim)
     goCoords = foldM goCoord
     goCoord :: Maybe Dim -> Coord -> Maybe (Maybe Dim)
@@ -325,7 +356,7 @@ data ByteOrder
     LittleEndianByteOrder
 
 -- | OGC type codes, as they appear in the low bits of the EWKB type header.
-pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, circularStringTypeCode, triangleTypeCode, polyhedralSurfaceTypeCode :: Word32
+pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, circularStringTypeCode, compoundCurveTypeCode, triangleTypeCode, polyhedralSurfaceTypeCode :: Word32
 pointTypeCode = 1
 lineStringTypeCode = 2
 polygonTypeCode = 3
@@ -334,6 +365,7 @@ multiLineStringTypeCode = 5
 multiPolygonTypeCode = 6
 geometryCollectionTypeCode = 7
 circularStringTypeCode = 8
+compoundCurveTypeCode = 9
 triangleTypeCode = 17
 polyhedralSurfaceTypeCode = 15
 
@@ -406,6 +438,7 @@ shapeToTypeCode = \case
   CircularStringShape {} -> circularStringTypeCode
   TriangleShape {} -> triangleTypeCode
   NurbsCurveShape {} -> nurbsCurveBaseTypeCode
+  CompoundCurveShape {} -> compoundCurveTypeCode
 
 -- | Name of the shape in the OGC vocabulary. Used for reporting decoding errors.
 shapeName :: Shape -> Text
@@ -421,6 +454,7 @@ shapeName = \case
   CircularStringShape {} -> "CircularString"
   TriangleShape {} -> "Triangle"
   NurbsCurveShape {} -> "NurbsCurve"
+  CompoundCurveShape {} -> "CompoundCurve"
 
 -- * Binary encoder
 
@@ -459,6 +493,7 @@ writeShape dim = \case
     [] -> Write.lWord32 0
     _ -> Write.lWord32 1 <> writeCoords coords
   NurbsCurveShape nurbsCurve -> writeNurbsCurve nurbsCurve
+  CompoundCurveShape segments -> writeCount segments <> foldMap writeSegment segments
   where
     writeCount :: [a] -> Write.Write
     writeCount = Write.lWord32 . fromIntegral . length
@@ -466,6 +501,10 @@ writeShape dim = \case
     writeCoords coords = writeCount coords <> foldMap writeCoord coords
     writeSubGeometry :: Shape -> Write.Write
     writeSubGeometry = writeGeometry Nothing dim
+    writeSegment :: CurveSegment -> Write.Write
+    writeSegment = \case
+      LineSegment coords -> writeSubGeometry (LineStringShape coords)
+      ArcSegment coords -> writeSubGeometry (CircularStringShape coords)
 
 -- | Encode the ordinates of a coordinate.
 --
@@ -604,6 +643,11 @@ readShape byteOrder dim typeCode
             )
   | typeCode == nurbsCurveBaseTypeCode =
       NurbsCurveShape <$> readNurbsCurve byteOrder dim
+  | typeCode == compoundCurveTypeCode =
+      CompoundCurveShape <$> readSubShapes "CompoundCurve" "LineString or CircularString" \case
+        LineStringShape coords -> Just (LineSegment coords)
+        CircularStringShape coords -> Just (ArcSegment coords)
+        _ -> Nothing
   | otherwise =
       throwError
         ( DecodingError
@@ -734,7 +778,14 @@ shapeGen dim size =
       [ MultiLineStringShape <$> QuickCheck.listOf (lineStringCoordsGen dim),
         MultiPolygonShape <$> QuickCheck.listOf (QuickCheck.listOf1 (ringCoordsGen dim)),
         PolyhedralSurfaceShape <$> QuickCheck.listOf (QuickCheck.listOf1 (ringCoordsGen dim)),
-        GeometryCollectionShape <$> QuickCheck.resize subSize (QuickCheck.listOf (shapeGen dim subSize))
+        GeometryCollectionShape <$> QuickCheck.resize subSize (QuickCheck.listOf (shapeGen dim subSize)),
+        CompoundCurveShape
+          <$> QuickCheck.listOf
+            ( QuickCheck.oneof
+                [ LineSegment <$> lineStringCoordsGen dim,
+                  ArcSegment <$> circularStringCoordsGen dim
+                ]
+            )
       ]
     subSize = div size 4
 
@@ -796,6 +847,11 @@ shrinkShape = \case
   -- 'shapeGen' never produces this constructor (see the comment there), so this is never called
   -- with one in practice. Covered only so the pattern match above stays exhaustive.
   NurbsCurveShape _ -> []
+  CompoundCurveShape segments ->
+    -- Members are dropped wholesale, never shrunk internally: shrinking a segment's own coordinate
+    -- list risks breaking the odd-≥3 invariant an 'ArcSegment' requires, the same reason
+    -- 'CircularStringShape' does not delegate to a plain 'shrinkMembers' either.
+    CompoundCurveShape <$> shrinkMembers segments
   where
     shrinkMembers :: [a] -> [[a]]
     shrinkMembers = QuickCheck.shrinkList (const [])

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -8,7 +8,7 @@ import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified PostgresqlTypes.Algebra
-import PostgresqlTypes.Geometry (Coord (..), Geometry, NurbsCurve (..), Shape (..))
+import PostgresqlTypes.Geometry (Coord (..), CurveSegment (..), Geometry, NurbsCurve (..), Shape (..))
 import qualified PostgresqlTypes.Geometry as Geometry
 import Test.Hspec
 import Test.QuickCheck
@@ -239,6 +239,42 @@ spec = do
             [ "01", -- NDR
               "11000000", -- Triangle
               "02000000" -- 2 rings, which a Triangle disallows
+            ]
+        )
+        `shouldSatisfy` isLeft
+
+    -- Fixture derived by hand from the EWKB layout (no live PostGIS instance required for this test):
+    -- a CompoundCurve made of one line segment through (0,0)-(1,1), followed by one arc segment
+    -- through (1,1), (2,2), (3,0), with no SRID.
+    --
+    -- Byte-order marker NDR (01), type 9 (CompoundCurve), no flags (09000000), member count 2
+    -- (02000000), then each member as a full sub-geometry: a LineString (type 2) of 2 coordinates,
+    -- and a CircularString (type 8) of 3 coordinates, each with its own byte-order marker.
+    let compoundCurveHex =
+          "01090000000200000001020000000200000000000000000000000000000000000000000000000000F03F000000000000F03F010800000003000000000000000000F03F000000000000F03F0000000000000040000000000000004000000000000008400000000000000000"
+        compoundCurve =
+          Geometry.refineFromShape
+            ( CompoundCurveShape
+                [ LineSegment [XyCoord 0 0, XyCoord 1 1],
+                  ArcSegment [XyCoord 1 1, XyCoord 2 2, XyCoord 3 0]
+                ]
+            )
+
+    it "decodes a compound curve" do
+      fmap Just (decodeHex compoundCurveHex) `shouldBe` Right compoundCurve
+
+    it "encodes a compound curve the way PostGIS does" do
+      fmap encodeHex compoundCurve `shouldBe` Just (Text.toLower compoundCurveHex)
+
+    it "rejects a compound curve whose member is neither a line nor an arc" do
+      decodeHex
+        ( mconcat
+            [ "01", -- NDR
+              "09000000", -- CompoundCurve
+              "01000000", -- 1 member
+              "01", -- NDR
+              "01000000", -- Point, where a LineString or CircularString is required
+              "000000000000F03F0000000000000040"
             ]
         )
         `shouldSatisfy` isLeft


### PR DESCRIPTION
## Summary
- Adds a `CurveSegment` type (`LineSegment [Coord] | ArcSegment [Coord]`) and `CompoundCurveShape [CurveSegment]` on `Shape` — a curve assembled from chained line/arc segments under WKB type code 9.
- `CurveSegment` deliberately doesn't reuse `Shape`, making illegal nesting (anything but a `LineString`/`CircularString` member) unrepresentable at compile time.
- Members are encoded/decoded as full sub-geometries via the existing `writeSubGeometry`/`readSubShapes` machinery, projecting `LineStringShape ↔ LineSegment` and `CircularStringShape ↔ ArcSegment`; any other member type fails with a `DecodingError` ("LineString or CircularString").
- `Arbitrary`/`shrink` reuse `lineStringCoordsGen`/`circularStringCoordsGen` so every generated segment is individually valid; shrink drops members wholesale rather than touching a segment's internal coordinate list (to preserve the arc's odd-≥3 invariant).
- Hand-built WKB fixture plus a decode-error test for a non-line/arc member.

## Test plan
- [x] `cabal build`
- [x] `cabal test unit-tests --test-options='--match Geometry'` — 48/48 examples
- [x] `cabal test integration-tests --test-options='--match "imresamu/postgis:17-3.5"'` — round-trips generated `CompoundCurveShape` values against a real PostGIS 17-3.5 server
- [x] `ormolu --mode check`

Closes #76