### PR TITLE
Geometry: add CurvePolygon and MultiCurve support (LWTYPE 10, 11)

### DIFF
--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -4,6 +4,7 @@ module PostgresqlTypes.Geometry
     Coord (..),
     NurbsCurve (..),
     CurveSegment (..),
+    Curve (..),
 
     -- * Accessors
     toSrid,
@@ -102,6 +103,19 @@ data Shape
     -- at compile time, the same reasoning that already led 'MultiPointShape' to store raw
     -- @['Coord']@ rather than @['Shape']@.
     CompoundCurveShape [CurveSegment]
+  | -- | Polygon whose rings may be curved: each ring is a full 'Curve' rather than a plain sequence
+    -- of coordinates.
+    --
+    -- Members are restricted to 'Curve' rather than 'Shape' for the same reason 'CompoundCurveShape'
+    -- is restricted to 'CurveSegment': a curve polygon's ring can only be a @LineString@, a
+    -- @CircularString@ or a @CompoundCurve@, never a @Polygon@ or anything else.
+    CurvePolygonShape [Curve]
+  | -- | Heterogeneous collection of curves.
+    --
+    -- Members are restricted to 'Curve' rather than 'Shape', again for the same reason as
+    -- 'CompoundCurveShape': a multi-curve's member can only be a @LineString@, a @CircularString@ or
+    -- a @CompoundCurve@, never a @Polygon@ or anything else.
+    MultiCurveShape [Curve]
   deriving stock (Eq, Ord, Show, Read)
 
 -- | Coordinate in one of the four dimensionalities PostGIS supports.
@@ -165,6 +179,19 @@ data CurveSegment
     ArcSegment [Coord]
   deriving stock (Eq, Ord, Show, Read)
 
+-- | Any curve: a single segment, or several chained end-to-end (an OGC/SQL-MM @CompoundCurve@).
+--
+-- The building block of 'CurvePolygonShape'\'s rings and 'MultiCurveShape'\'s members. Deliberately
+-- does not reuse 'Shape', for the same reason 'CurveSegment' does not: a ring or member here can
+-- only be a @LineString@, a @CircularString@ or a @CompoundCurve@, never a @Polygon@ or anything else.
+data Curve
+  = -- | Single segment, wire-compatible with 'LineStringShape' or 'CircularStringShape', depending
+    -- on the wrapped 'CurveSegment'\'s own constructor.
+    SegmentCurve CurveSegment
+  | -- | Several segments chained end to end, wire-compatible with 'CompoundCurveShape'.
+    ChainedCurve [CurveSegment]
+  deriving stock (Eq, Ord, Show, Read)
+
 instance Hashable Geometry where
   hashWithSalt salt (Geometry srid shape) =
     salt `hashWithSalt` srid `hashWithSalt` shape
@@ -184,6 +211,8 @@ instance Hashable Shape where
     NurbsCurveShape nurbsCurve -> salt `hashWithSalt` (10 :: Int) `hashWithSalt` nurbsCurve
     TinShape triangles -> salt `hashWithSalt` (11 :: Int) `hashWithSalt` triangles
     CompoundCurveShape segments -> salt `hashWithSalt` (12 :: Int) `hashWithSalt` segments
+    CurvePolygonShape curves -> salt `hashWithSalt` (13 :: Int) `hashWithSalt` curves
+    MultiCurveShape curves -> salt `hashWithSalt` (14 :: Int) `hashWithSalt` curves
 
 instance Hashable Coord where
   hashWithSalt salt = \case
@@ -200,6 +229,11 @@ instance Hashable CurveSegment where
   hashWithSalt salt = \case
     LineSegment coords -> salt `hashWithSalt` (0 :: Int) `hashWithSalt` coords
     ArcSegment coords -> salt `hashWithSalt` (1 :: Int) `hashWithSalt` coords
+
+instance Hashable Curve where
+  hashWithSalt salt = \case
+    SegmentCurve segment -> salt `hashWithSalt` (0 :: Int) `hashWithSalt` segment
+    ChainedCurve segments -> salt `hashWithSalt` (1 :: Int) `hashWithSalt` segments
 
 instance Arbitrary Geometry where
   arbitrary = do
@@ -332,10 +366,16 @@ shapeDim shape = fromMaybe XyDim <$> goShape Nothing shape
       NurbsCurveShape (NurbsCurve _ controlPoints _) -> goCoords acc (fst <$> controlPoints)
       TinShape triangles -> foldM goCoords acc triangles
       CompoundCurveShape segments -> foldM goSegment acc segments
+      CurvePolygonShape curves -> foldM goCurve acc curves
+      MultiCurveShape curves -> foldM goCurve acc curves
     goSegment :: Maybe Dim -> CurveSegment -> Maybe (Maybe Dim)
     goSegment acc = \case
       LineSegment coords -> goCoords acc coords
       ArcSegment coords -> goCoords acc coords
+    goCurve :: Maybe Dim -> Curve -> Maybe (Maybe Dim)
+    goCurve acc = \case
+      SegmentCurve segment -> goSegment acc segment
+      ChainedCurve segments -> foldM goSegment acc segments
     goCoords :: Maybe Dim -> [Coord] -> Maybe (Maybe Dim)
     goCoords = foldM goCoord
     goCoord :: Maybe Dim -> Coord -> Maybe (Maybe Dim)
@@ -362,7 +402,7 @@ data ByteOrder
     LittleEndianByteOrder
 
 -- | OGC type codes, as they appear in the low bits of the EWKB type header.
-pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, circularStringTypeCode, triangleTypeCode, polyhedralSurfaceTypeCode, tinTypeCode, compoundCurveTypeCode :: Word32
+pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, circularStringTypeCode, triangleTypeCode, polyhedralSurfaceTypeCode, tinTypeCode, compoundCurveTypeCode, curvePolygonTypeCode, multiCurveTypeCode :: Word32
 pointTypeCode = 1
 lineStringTypeCode = 2
 polygonTypeCode = 3
@@ -372,6 +412,8 @@ multiPolygonTypeCode = 6
 geometryCollectionTypeCode = 7
 circularStringTypeCode = 8
 compoundCurveTypeCode = 9
+curvePolygonTypeCode = 10
+multiCurveTypeCode = 11
 triangleTypeCode = 17
 polyhedralSurfaceTypeCode = 15
 tinTypeCode = 16
@@ -447,6 +489,8 @@ shapeToTypeCode = \case
   NurbsCurveShape {} -> nurbsCurveBaseTypeCode
   TinShape {} -> tinTypeCode
   CompoundCurveShape {} -> compoundCurveTypeCode
+  CurvePolygonShape {} -> curvePolygonTypeCode
+  MultiCurveShape {} -> multiCurveTypeCode
 
 -- | Name of the shape in the OGC vocabulary. Used for reporting decoding errors.
 shapeName :: Shape -> Text
@@ -464,6 +508,8 @@ shapeName = \case
   NurbsCurveShape {} -> "NurbsCurve"
   TinShape {} -> "TIN"
   CompoundCurveShape {} -> "CompoundCurve"
+  CurvePolygonShape {} -> "CurvePolygon"
+  MultiCurveShape {} -> "MultiCurve"
 
 -- * Binary encoder
 
@@ -504,6 +550,8 @@ writeShape dim = \case
   NurbsCurveShape nurbsCurve -> writeNurbsCurve nurbsCurve
   TinShape triangles -> writeCount triangles <> foldMap (writeSubGeometry . TriangleShape) triangles
   CompoundCurveShape segments -> writeCount segments <> foldMap writeSegment segments
+  CurvePolygonShape curves -> writeCount curves <> foldMap writeCurve curves
+  MultiCurveShape curves -> writeCount curves <> foldMap writeCurve curves
   where
     writeCount :: [a] -> Write.Write
     writeCount = Write.lWord32 . fromIntegral . length
@@ -515,6 +563,10 @@ writeShape dim = \case
     writeSegment = \case
       LineSegment coords -> writeSubGeometry (LineStringShape coords)
       ArcSegment coords -> writeSubGeometry (CircularStringShape coords)
+    writeCurve :: Curve -> Write.Write
+    writeCurve = \case
+      SegmentCurve segment -> writeSegment segment
+      ChainedCurve segments -> writeSubGeometry (CompoundCurveShape segments)
 
 -- | Encode the ordinates of a coordinate.
 --
@@ -662,6 +714,10 @@ readShape byteOrder dim typeCode
         LineStringShape coords -> Just (LineSegment coords)
         CircularStringShape coords -> Just (ArcSegment coords)
         _ -> Nothing
+  | typeCode == curvePolygonTypeCode =
+      CurvePolygonShape <$> readSubShapes "CurvePolygon" "LineString, CircularString or CompoundCurve" readCurveProjection
+  | typeCode == multiCurveTypeCode =
+      MultiCurveShape <$> readSubShapes "MultiCurve" "LineString, CircularString or CompoundCurve" readCurveProjection
   | otherwise =
       throwError
         ( DecodingError
@@ -696,6 +752,14 @@ readShape byteOrder dim typeCode
                   [name]
                   (UnexpectedValueDecodingErrorReason subShapeName (shapeName shape))
               )
+    -- Projection shared by 'CurvePolygonShape' and 'MultiCurveShape': both admit the same three
+    -- shapes as a ring\/member, wire-compatible with 'Curve'\'s own two constructors.
+    readCurveProjection :: Shape -> Maybe Curve
+    readCurveProjection = \case
+      LineStringShape coords -> Just (SegmentCurve (LineSegment coords))
+      CircularStringShape coords -> Just (SegmentCurve (ArcSegment coords))
+      CompoundCurveShape segments -> Just (ChainedCurve segments)
+      _ -> Nothing
 
 readCoord :: ByteOrder -> Dim -> PtrPeeker.Variable Coord
 readCoord byteOrder = \case
@@ -793,13 +857,9 @@ shapeGen dim size =
         MultiPolygonShape <$> QuickCheck.listOf (QuickCheck.listOf1 (ringCoordsGen dim)),
         PolyhedralSurfaceShape <$> QuickCheck.listOf (QuickCheck.listOf1 (ringCoordsGen dim)),
         TinShape <$> QuickCheck.listOf (QuickCheck.oneof [pure [], ringCoordsGen dim]),
-        CompoundCurveShape
-          <$> QuickCheck.listOf
-            ( QuickCheck.oneof
-                [ LineSegment <$> lineStringCoordsGen dim,
-                  ArcSegment <$> circularStringCoordsGen dim
-                ]
-            ),
+        CompoundCurveShape <$> QuickCheck.listOf (segmentGen dim),
+        CurvePolygonShape <$> QuickCheck.listOf (curveGen dim),
+        MultiCurveShape <$> QuickCheck.listOf (curveGen dim),
         GeometryCollectionShape <$> QuickCheck.resize subSize (QuickCheck.listOf (shapeGen dim subSize))
       ]
     subSize = div size 4
@@ -833,6 +893,23 @@ coordGen = \case
   XyzDim -> XyzCoord <$> arbitrary <*> arbitrary <*> arbitrary
   XymDim -> XymCoord <$> arbitrary <*> arbitrary <*> arbitrary
   XyzmDim -> XyzmCoord <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+-- | Generate one curve segment, matching 'CurveSegment'\'s own two constructors.
+segmentGen :: Dim -> QuickCheck.Gen CurveSegment
+segmentGen dim =
+  QuickCheck.oneof
+    [ LineSegment <$> lineStringCoordsGen dim,
+      ArcSegment <$> circularStringCoordsGen dim
+    ]
+
+-- | Generate a curve: either a single segment or several chained end to end, matching 'Curve'\'s own
+-- two constructors.
+curveGen :: Dim -> QuickCheck.Gen Curve
+curveGen dim =
+  QuickCheck.oneof
+    [ SegmentCurve <$> segmentGen dim,
+      ChainedCurve <$> QuickCheck.listOf (segmentGen dim)
+    ]
 
 -- | Shrink a shape by dropping members of its collections.
 --
@@ -869,6 +946,11 @@ shrinkShape = \case
     -- list risks breaking the odd-≥3 invariant an 'ArcSegment' requires, the same reason
     -- 'CircularStringShape' does not delegate to a plain 'shrinkMembers' either.
     CompoundCurveShape <$> shrinkMembers segments
+  CurvePolygonShape curves ->
+    -- Same reasoning as 'CompoundCurveShape': members are dropped wholesale, never shrunk internally.
+    CurvePolygonShape <$> shrinkMembers curves
+  MultiCurveShape curves ->
+    MultiCurveShape <$> shrinkMembers curves
   where
     shrinkMembers :: [a] -> [[a]]
     shrinkMembers = QuickCheck.shrinkList (const [])

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -8,7 +8,7 @@ import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified PostgresqlTypes.Algebra
-import PostgresqlTypes.Geometry (Coord (..), CurveSegment (..), Geometry, NurbsCurve (..), Shape (..))
+import PostgresqlTypes.Geometry (Coord (..), Curve (..), CurveSegment (..), Geometry, NurbsCurve (..), Shape (..))
 import qualified PostgresqlTypes.Geometry as Geometry
 import Test.Hspec
 import Test.QuickCheck
@@ -317,6 +317,102 @@ spec = do
               "01", -- NDR
               "01000000", -- Point, where a LineString or CircularString is required
               "000000000000F03F0000000000000040"
+            ]
+        )
+        `shouldSatisfy` isLeft
+
+    -- Fixture derived by hand from the EWKB layout (no live PostGIS instance required for this test):
+    -- a CurvePolygon of two rings, exercising both of 'Curve'\'s constructors as ring members: a
+    -- plain closed square via 'SegmentCurve' wrapping a 'LineSegment', and a closed ring assembled
+    -- from a line and an arc via 'ChainedCurve'.
+    --
+    -- Byte-order marker NDR (01), type 10 (CurvePolygon), no flags (0A000000), ring count 2
+    -- (02000000), then each ring as a full sub-geometry: a LineString (type 2) of 5 coordinates
+    -- forming the square (0,0)-(4,0)-(4,4)-(0,4)-(0,0), and a CompoundCurve (type 9) of 2 members — a
+    -- LineString from (1,1) to (2,1), then a CircularString through (2,1), (2,2), (1,1) — closing the
+    -- ring back on its start.
+    let curvePolygonHex =
+          "010A000000020000000102000000050000000000000000000000000000000000000000000000000010400000000000000000000000000000104000000000000010400000000000000000000000000000104000000000000000000000000000000000010900000002000000010200000002000000000000000000F03F000000000000F03F0000000000000040000000000000F03F0108000000030000000000000000000040000000000000F03F00000000000000400000000000000040000000000000F03F000000000000F03F"
+        curvePolygon =
+          Geometry.refineFromShape
+            ( CurvePolygonShape
+                [ SegmentCurve (LineSegment [XyCoord 0 0, XyCoord 4 0, XyCoord 4 4, XyCoord 0 4, XyCoord 0 0]),
+                  ChainedCurve
+                    [ LineSegment [XyCoord 1 1, XyCoord 2 1],
+                      ArcSegment [XyCoord 2 1, XyCoord 2 2, XyCoord 1 1]
+                    ]
+                ]
+            )
+
+    it "decodes a curve polygon" do
+      fmap Just (decodeHex curvePolygonHex) `shouldBe` Right curvePolygon
+
+    it "encodes a curve polygon the way PostGIS does" do
+      fmap encodeHex curvePolygon `shouldBe` Just (Text.toLower curvePolygonHex)
+
+    it "rejects a curve polygon whose ring is a polygon" do
+      decodeHex
+        ( mconcat
+            [ "01", -- NDR
+              "0A000000", -- CurvePolygon
+              "01000000", -- 1 ring
+              "01", -- NDR
+              "03000000", -- Polygon, where a LineString, CircularString or CompoundCurve is required
+              "01000000", -- 1 ring
+              "04000000", -- 4 coordinates
+              "0000000000000000", -- (0, 0)
+              "0000000000000000",
+              "000000000000F03F", -- (1, 0)
+              "0000000000000000",
+              "0000000000000000", -- (0, 1)
+              "000000000000F03F",
+              "0000000000000000", -- (0, 0), closing the ring
+              "0000000000000000"
+            ]
+        )
+        `shouldSatisfy` isLeft
+
+    -- Fixture derived by hand from the EWKB layout (no live PostGIS instance required for this test):
+    -- a MultiCurve made of the same line and arc as the 'compoundCurveHex' fixture above, but as two
+    -- independent members rather than segments chained into one 'CompoundCurveShape'.
+    --
+    -- Byte-order marker NDR (01), type 11 (MultiCurve), no flags (0B000000), member count 2
+    -- (02000000), then each member as a full sub-geometry: a LineString (type 2) of 2 coordinates,
+    -- and a CircularString (type 8) of 3 coordinates.
+    let multiCurveHex =
+          "010B0000000200000001020000000200000000000000000000000000000000000000000000000000F03F000000000000F03F010800000003000000000000000000F03F000000000000F03F0000000000000040000000000000004000000000000008400000000000000000"
+        multiCurve =
+          Geometry.refineFromShape
+            ( MultiCurveShape
+                [ SegmentCurve (LineSegment [XyCoord 0 0, XyCoord 1 1]),
+                  SegmentCurve (ArcSegment [XyCoord 1 1, XyCoord 2 2, XyCoord 3 0])
+                ]
+            )
+
+    it "decodes a multi-curve" do
+      fmap Just (decodeHex multiCurveHex) `shouldBe` Right multiCurve
+
+    it "encodes a multi-curve the way PostGIS does" do
+      fmap encodeHex multiCurve `shouldBe` Just (Text.toLower multiCurveHex)
+
+    it "rejects a multi-curve whose member is a polygon" do
+      decodeHex
+        ( mconcat
+            [ "01", -- NDR
+              "0B000000", -- MultiCurve
+              "01000000", -- 1 member
+              "01", -- NDR
+              "03000000", -- Polygon, where a LineString, CircularString or CompoundCurve is required
+              "01000000", -- 1 ring
+              "04000000", -- 4 coordinates
+              "0000000000000000", -- (0, 0)
+              "0000000000000000",
+              "000000000000F03F", -- (1, 0)
+              "0000000000000000",
+              "0000000000000000", -- (0, 1)
+              "000000000000F03F",
+              "0000000000000000", -- (0, 0), closing the ring
+              "0000000000000000"
             ]
         )
         `shouldSatisfy` isLeft


### PR DESCRIPTION
## Summary
- Adds a `Curve` type (`SegmentCurve CurveSegment | ChainedCurve [CurveSegment]`) and two `Shape` constructors: `CurvePolygonShape [Curve]` (WKB type code 10) and `MultiCurveShape [Curve]` (type code 11).
- Rings/members can be a `LineString`, `CircularString`, or `CompoundCurve` — never a `Polygon` or anything else — encoded via the same "count + N full sub-geometries" pattern already used by `TinShape`/`CompoundCurveShape`; anything else fails with a `DecodingError` ("LineString, CircularString or CompoundCurve").
- `Arbitrary`/`shrink` reuse (and factor out) the segment generator introduced for `CompoundCurveShape` — no behavioral change to that generator.
- Hand-built WKB fixtures exercising all three ring/member projections, plus decode-error tests for both constructors.

## Test plan
- [x] `cabal build`
- [x] `cabal test unit-tests --test-options='--match Geometry'` — 54/54 examples
- [x] `cabal test integration-tests --test-options='--match "imresamu/postgis:17-3.5"'` — round-trips generated `CurvePolygonShape`/`MultiCurveShape` values against a real PostGIS 17-3.5 server
- [x] `ormolu --mode check`

Closes #77