### PR TITLE
Geometry: add MultiSurface support (LWTYPE 12)

### DIFF
--- a/src/library/PostgresqlTypes/Geometry.hs
+++ b/src/library/PostgresqlTypes/Geometry.hs
@@ -5,6 +5,7 @@ module PostgresqlTypes.Geometry
     NurbsCurve (..),
     CurveSegment (..),
     Curve (..),
+    Surface (..),
 
     -- * Accessors
     toSrid,
@@ -116,6 +117,12 @@ data Shape
     -- 'CompoundCurveShape': a multi-curve's member can only be a @LineString@, a @CircularString@ or
     -- a @CompoundCurve@, never a @Polygon@ or anything else.
     MultiCurveShape [Curve]
+  | -- | Heterogeneous collection of surfaces.
+    --
+    -- Members are restricted to 'Surface' rather than 'Shape', for the same reason
+    -- 'CompoundCurveShape' is restricted to 'CurveSegment': a multi-surface's member can only be a
+    -- @Polygon@ or a @CurvePolygon@, never anything else.
+    MultiSurfaceShape [Surface]
   deriving stock (Eq, Ord, Show, Read)
 
 -- | Coordinate in one of the four dimensionalities PostGIS supports.
@@ -192,6 +199,18 @@ data Curve
     ChainedCurve [CurveSegment]
   deriving stock (Eq, Ord, Show, Read)
 
+-- | Any surface: a plain polygon, or one whose rings may be curved (an OGC/SQL-MM @CurvePolygon@).
+--
+-- The building block of 'MultiSurfaceShape'\'s members. Deliberately does not reuse 'Shape', for the
+-- same reason 'Curve' does not: a member here can only be a @Polygon@ or a @CurvePolygon@, never
+-- anything else.
+data Surface
+  = -- | Plain polygon, wire-compatible with 'PolygonShape'.
+    PolygonSurface [[Coord]]
+  | -- | Polygon with possibly curved rings, wire-compatible with 'CurvePolygonShape'.
+    CurvedSurface [Curve]
+  deriving stock (Eq, Ord, Show, Read)
+
 instance Hashable Geometry where
   hashWithSalt salt (Geometry srid shape) =
     salt `hashWithSalt` srid `hashWithSalt` shape
@@ -213,6 +232,7 @@ instance Hashable Shape where
     CompoundCurveShape segments -> salt `hashWithSalt` (12 :: Int) `hashWithSalt` segments
     CurvePolygonShape curves -> salt `hashWithSalt` (13 :: Int) `hashWithSalt` curves
     MultiCurveShape curves -> salt `hashWithSalt` (14 :: Int) `hashWithSalt` curves
+    MultiSurfaceShape surfaces -> salt `hashWithSalt` (15 :: Int) `hashWithSalt` surfaces
 
 instance Hashable Coord where
   hashWithSalt salt = \case
@@ -234,6 +254,11 @@ instance Hashable Curve where
   hashWithSalt salt = \case
     SegmentCurve segment -> salt `hashWithSalt` (0 :: Int) `hashWithSalt` segment
     ChainedCurve segments -> salt `hashWithSalt` (1 :: Int) `hashWithSalt` segments
+
+instance Hashable Surface where
+  hashWithSalt salt = \case
+    PolygonSurface rings -> salt `hashWithSalt` (0 :: Int) `hashWithSalt` rings
+    CurvedSurface curves -> salt `hashWithSalt` (1 :: Int) `hashWithSalt` curves
 
 instance Arbitrary Geometry where
   arbitrary = do
@@ -368,6 +393,7 @@ shapeDim shape = fromMaybe XyDim <$> goShape Nothing shape
       CompoundCurveShape segments -> foldM goSegment acc segments
       CurvePolygonShape curves -> foldM goCurve acc curves
       MultiCurveShape curves -> foldM goCurve acc curves
+      MultiSurfaceShape surfaces -> foldM goSurface acc surfaces
     goSegment :: Maybe Dim -> CurveSegment -> Maybe (Maybe Dim)
     goSegment acc = \case
       LineSegment coords -> goCoords acc coords
@@ -376,6 +402,10 @@ shapeDim shape = fromMaybe XyDim <$> goShape Nothing shape
     goCurve acc = \case
       SegmentCurve segment -> goSegment acc segment
       ChainedCurve segments -> foldM goSegment acc segments
+    goSurface :: Maybe Dim -> Surface -> Maybe (Maybe Dim)
+    goSurface acc = \case
+      PolygonSurface rings -> foldM goCoords acc rings
+      CurvedSurface curves -> foldM goCurve acc curves
     goCoords :: Maybe Dim -> [Coord] -> Maybe (Maybe Dim)
     goCoords = foldM goCoord
     goCoord :: Maybe Dim -> Coord -> Maybe (Maybe Dim)
@@ -402,7 +432,7 @@ data ByteOrder
     LittleEndianByteOrder
 
 -- | OGC type codes, as they appear in the low bits of the EWKB type header.
-pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, circularStringTypeCode, triangleTypeCode, polyhedralSurfaceTypeCode, tinTypeCode, compoundCurveTypeCode, curvePolygonTypeCode, multiCurveTypeCode :: Word32
+pointTypeCode, lineStringTypeCode, polygonTypeCode, multiPointTypeCode, multiLineStringTypeCode, multiPolygonTypeCode, geometryCollectionTypeCode, circularStringTypeCode, triangleTypeCode, polyhedralSurfaceTypeCode, tinTypeCode, compoundCurveTypeCode, curvePolygonTypeCode, multiCurveTypeCode, multiSurfaceTypeCode :: Word32
 pointTypeCode = 1
 lineStringTypeCode = 2
 polygonTypeCode = 3
@@ -414,6 +444,7 @@ circularStringTypeCode = 8
 compoundCurveTypeCode = 9
 curvePolygonTypeCode = 10
 multiCurveTypeCode = 11
+multiSurfaceTypeCode = 12
 triangleTypeCode = 17
 polyhedralSurfaceTypeCode = 15
 tinTypeCode = 16
@@ -491,6 +522,7 @@ shapeToTypeCode = \case
   CompoundCurveShape {} -> compoundCurveTypeCode
   CurvePolygonShape {} -> curvePolygonTypeCode
   MultiCurveShape {} -> multiCurveTypeCode
+  MultiSurfaceShape {} -> multiSurfaceTypeCode
 
 -- | Name of the shape in the OGC vocabulary. Used for reporting decoding errors.
 shapeName :: Shape -> Text
@@ -510,6 +542,7 @@ shapeName = \case
   CompoundCurveShape {} -> "CompoundCurve"
   CurvePolygonShape {} -> "CurvePolygon"
   MultiCurveShape {} -> "MultiCurve"
+  MultiSurfaceShape {} -> "MultiSurface"
 
 -- * Binary encoder
 
@@ -552,6 +585,7 @@ writeShape dim = \case
   CompoundCurveShape segments -> writeCount segments <> foldMap writeSegment segments
   CurvePolygonShape curves -> writeCount curves <> foldMap writeCurve curves
   MultiCurveShape curves -> writeCount curves <> foldMap writeCurve curves
+  MultiSurfaceShape surfaces -> writeCount surfaces <> foldMap writeSurface surfaces
   where
     writeCount :: [a] -> Write.Write
     writeCount = Write.lWord32 . fromIntegral . length
@@ -567,6 +601,10 @@ writeShape dim = \case
     writeCurve = \case
       SegmentCurve segment -> writeSegment segment
       ChainedCurve segments -> writeSubGeometry (CompoundCurveShape segments)
+    writeSurface :: Surface -> Write.Write
+    writeSurface = \case
+      PolygonSurface rings -> writeSubGeometry (PolygonShape rings)
+      CurvedSurface curves -> writeSubGeometry (CurvePolygonShape curves)
 
 -- | Encode the ordinates of a coordinate.
 --
@@ -718,6 +756,8 @@ readShape byteOrder dim typeCode
       CurvePolygonShape <$> readSubShapes "CurvePolygon" "LineString, CircularString or CompoundCurve" readCurveProjection
   | typeCode == multiCurveTypeCode =
       MultiCurveShape <$> readSubShapes "MultiCurve" "LineString, CircularString or CompoundCurve" readCurveProjection
+  | typeCode == multiSurfaceTypeCode =
+      MultiSurfaceShape <$> readSubShapes "MultiSurface" "Polygon or CurvePolygon" readSurfaceProjection
   | otherwise =
       throwError
         ( DecodingError
@@ -759,6 +799,13 @@ readShape byteOrder dim typeCode
       LineStringShape coords -> Just (SegmentCurve (LineSegment coords))
       CircularStringShape coords -> Just (SegmentCurve (ArcSegment coords))
       CompoundCurveShape segments -> Just (ChainedCurve segments)
+      _ -> Nothing
+    -- Projection for 'MultiSurfaceShape': a member is either a plain 'PolygonShape' or a
+    -- 'CurvePolygonShape', wire-compatible with 'Surface'\'s own two constructors.
+    readSurfaceProjection :: Shape -> Maybe Surface
+    readSurfaceProjection = \case
+      PolygonShape rings -> Just (PolygonSurface rings)
+      CurvePolygonShape curves -> Just (CurvedSurface curves)
       _ -> Nothing
 
 readCoord :: ByteOrder -> Dim -> PtrPeeker.Variable Coord
@@ -860,6 +907,7 @@ shapeGen dim size =
         CompoundCurveShape <$> QuickCheck.listOf (segmentGen dim),
         CurvePolygonShape <$> QuickCheck.listOf (curveGen dim),
         MultiCurveShape <$> QuickCheck.listOf (curveGen dim),
+        MultiSurfaceShape <$> QuickCheck.listOf (surfaceGen dim),
         GeometryCollectionShape <$> QuickCheck.resize subSize (QuickCheck.listOf (shapeGen dim subSize))
       ]
     subSize = div size 4
@@ -911,6 +959,15 @@ curveGen dim =
       ChainedCurve <$> QuickCheck.listOf (segmentGen dim)
     ]
 
+-- | Generate a surface, matching 'Surface'\'s own two constructors. A plain polygon surface has at
+-- least one ring, matching 'PolygonShape'\'s own generator.
+surfaceGen :: Dim -> QuickCheck.Gen Surface
+surfaceGen dim =
+  QuickCheck.oneof
+    [ PolygonSurface . pure <$> ringCoordsGen dim,
+      CurvedSurface <$> QuickCheck.listOf (curveGen dim)
+    ]
+
 -- | Shrink a shape by dropping members of its collections.
 --
 -- Individual coordinates are never dropped or shrunk: that would either change the dimensionality of
@@ -951,6 +1008,9 @@ shrinkShape = \case
     CurvePolygonShape <$> shrinkMembers curves
   MultiCurveShape curves ->
     MultiCurveShape <$> shrinkMembers curves
+  MultiSurfaceShape surfaces ->
+    -- Same reasoning as 'MultiCurveShape': members are dropped wholesale, never shrunk internally.
+    MultiSurfaceShape <$> shrinkMembers surfaces
   where
     shrinkMembers :: [a] -> [[a]]
     shrinkMembers = QuickCheck.shrinkList (const [])

--- a/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
+++ b/src/unit-tests/PostgresqlTypes/GeometrySpec.hs
@@ -8,7 +8,7 @@ import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified PostgresqlTypes.Algebra
-import PostgresqlTypes.Geometry (Coord (..), Curve (..), CurveSegment (..), Geometry, NurbsCurve (..), Shape (..))
+import PostgresqlTypes.Geometry (Coord (..), Curve (..), CurveSegment (..), Geometry, NurbsCurve (..), Shape (..), Surface (..))
 import qualified PostgresqlTypes.Geometry as Geometry
 import Test.Hspec
 import Test.QuickCheck
@@ -413,6 +413,45 @@ spec = do
               "000000000000F03F",
               "0000000000000000", -- (0, 0), closing the ring
               "0000000000000000"
+            ]
+        )
+        `shouldSatisfy` isLeft
+
+    -- Fixture derived by hand from the EWKB layout (no live PostGIS instance required for this test):
+    -- a MultiSurface of two members, exercising both of 'Surface'\'s constructors: a plain triangular
+    -- 'Polygon' (wire-compatible with 'PolygonSurface') and a 'CurvePolygon' whose one ring happens
+    -- to be a plain 'LineString' (wire-compatible with 'CurvedSurface').
+    --
+    -- Byte-order marker NDR (01), type 12 (MultiSurface), no flags (0C000000), member count 2
+    -- (02000000), then each member as a full sub-geometry: a Polygon (type 3) of 1 ring of 4
+    -- coordinates forming the closed triangle (0,0)-(1,0)-(0,1)-(0,0), and a CurvePolygon (type 10)
+    -- of 1 ring, that ring itself a LineString (type 2) of 5 coordinates forming the closed square
+    -- (0,0)-(4,0)-(4,4)-(0,4)-(0,0).
+    let multiSurfaceHex =
+          "010C000000020000000103000000010000000400000000000000000000000000000000000000000000000000F03F00000000000000000000000000000000000000000000F03F00000000000000000000000000000000010A000000010000000102000000050000000000000000000000000000000000000000000000000010400000000000000000000000000000104000000000000010400000000000000000000000000000104000000000000000000000000000000000"
+        multiSurface =
+          Geometry.refineFromShape
+            ( MultiSurfaceShape
+                [ PolygonSurface [[XyCoord 0 0, XyCoord 1 0, XyCoord 0 1, XyCoord 0 0]],
+                  CurvedSurface [SegmentCurve (LineSegment [XyCoord 0 0, XyCoord 4 0, XyCoord 4 4, XyCoord 0 4, XyCoord 0 0])]
+                ]
+            )
+
+    it "decodes a multi-surface" do
+      fmap Just (decodeHex multiSurfaceHex) `shouldBe` Right multiSurface
+
+    it "encodes a multi-surface the way PostGIS does" do
+      fmap encodeHex multiSurface `shouldBe` Just (Text.toLower multiSurfaceHex)
+
+    it "rejects a multi-surface whose member is neither a polygon nor a curve polygon" do
+      decodeHex
+        ( mconcat
+            [ "01", -- NDR
+              "0C000000", -- MultiSurface
+              "01000000", -- 1 member
+              "01", -- NDR
+              "01000000", -- Point, where a Polygon or CurvePolygon is required
+              "000000000000F03F0000000000000040"
             ]
         )
         `shouldSatisfy` isLeft


### PR DESCRIPTION
## Summary
- Adds a `Surface` type (`PolygonSurface [[Coord]] | CurvedSurface [Curve]`) and a `MultiSurfaceShape [Surface]` constructor on `Shape` under WKB type code 12.
- Members can be a `Polygon` or a `CurvePolygon` — never anything else — encoded via the same "count + N full sub-geometries" pattern as the other collection shapes; anything else fails with a `DecodingError` ("Polygon or CurvePolygon").
- `Arbitrary`/`shrink` generate multi-surfaces mixing plain and curved members.
- Hand-built WKB fixture mixing both `Surface` variants, plus a decode-error test.

## Test plan
- [x] `cabal build`
- [x] `cabal test unit-tests --test-options='--match Geometry'` — 57/57 examples
- [x] `cabal test integration-tests --test-options='--match "imresamu/postgis:17-3.5"'` — round-trips generated `MultiSurfaceShape` values against a real PostGIS 17-3.5 server
- [x] `ormolu --mode check`

Closes #78